### PR TITLE
feat(front): add a self-hosted Umami analytics adapter

### DIFF
--- a/packages/front/.env.example
+++ b/packages/front/.env.example
@@ -7,3 +7,12 @@ VITE_WEBSOCKET_HOST=ws://localhost:4000
 
 # Google Analytics 4 measurement id. Leave empty to load no tag at all.
 VITE_GA_MEASUREMENT_ID=
+
+# Self-hosted Umami. Setting both of these switches analytics to Umami and
+# removes the cookie banner entirely: the tracker sets no cookie and stores no
+# visitor identifier, so there is nothing to consent to. Takes precedence over
+# VITE_GA_MEASUREMENT_ID, which is then ignored rather than sent in parallel.
+VITE_UMAMI_SRC=
+VITE_UMAMI_WEBSITE_ID=
+# Only when the collect API answers on another origin than the script.
+VITE_UMAMI_HOST_URL=

--- a/packages/front/.env.production
+++ b/packages/front/.env.production
@@ -8,3 +8,10 @@ VITE_WEBSOCKET_HOST=wss://gutenku.xyz
 # Google Analytics 4. Public by design — it ships in the client bundle.
 # Ignored in native builds, which skip the web tag entirely.
 VITE_GA_MEASUREMENT_ID=G-G82ZDC1K47
+
+# Self-hosted Umami. Filling both switches the site to Umami and drops the
+# cookie banner; GA above is then ignored. Left empty on purpose — the switch
+# is a deliberate move, not a side effect of a deploy.
+VITE_UMAMI_SRC=
+VITE_UMAMI_WEBSITE_ID=
+VITE_UMAMI_HOST_URL=

--- a/packages/front/README.md
+++ b/packages/front/README.md
@@ -36,14 +36,18 @@ Two providers ship behind one `AnalyticsProvider` interface
 (`src/services/analytics/`). Which one runs is decided by the env alone, and it
 decides the cookie banner with it.
 
-| Mode    | Env                                               | Cookie banner |
-| ------- | ------------------------------------------------- | ------------- |
-| `none`  | nothing set — also every native (Capacitor) build | none          |
-| `ga`    | `VITE_GA_MEASUREMENT_ID`                          | shown         |
-| `umami` | `VITE_UMAMI_SRC` **and** `VITE_UMAMI_WEBSITE_ID`  | none          |
+| Mode    | Env                                              | Cookie banner |
+| ------- | ------------------------------------------------ | ------------- |
+| `none`  | nothing set                                      | none          |
+| `ga`    | `VITE_GA_MEASUREMENT_ID`                         | shown         |
+| `umami` | `VITE_UMAMI_SRC` **and** `VITE_UMAMI_WEBSITE_ID` | none          |
 
 Umami wins when both are configured, so a half-finished migration measures once
-instead of twice. Self-hosted Umami sets no cookie and stores no visitor
+instead of twice. The mode is read from the env and nothing else: `cap:build`
+ships the very `dist` that vite-ssg prerendered, so an answer that varied by
+platform would prerender markup the device then hydrates without. Native
+(Capacitor) builds load no web tag all the same — the providers rule that out
+themselves. Self-hosted Umami sets no cookie and stores no visitor
 identifier, so there is nothing to consent to: in that mode the banner and the
 footer's cookie control are not rendered at all, and analytics starts on its
 own instead of waiting for a decision. Decisions already stored under GA are

--- a/packages/front/README.md
+++ b/packages/front/README.md
@@ -30,6 +30,39 @@ Or copy env variables first:
 cp .env.example .env
 ```
 
+## Analytics
+
+Two providers ship behind one `AnalyticsProvider` interface
+(`src/services/analytics/`). Which one runs is decided by the env alone, and it
+decides the cookie banner with it.
+
+| Mode    | Env                                               | Cookie banner |
+| ------- | ------------------------------------------------- | ------------- |
+| `none`  | nothing set — also every native (Capacitor) build | none          |
+| `ga`    | `VITE_GA_MEASUREMENT_ID`                          | shown         |
+| `umami` | `VITE_UMAMI_SRC` **and** `VITE_UMAMI_WEBSITE_ID`  | none          |
+
+Umami wins when both are configured, so a half-finished migration measures once
+instead of twice. Self-hosted Umami sets no cookie and stores no visitor
+identifier, so there is nothing to consent to: in that mode the banner and the
+footer's cookie control are not rendered at all, and analytics starts on its
+own instead of waiting for a decision. Decisions already stored under GA are
+left in place, so switching back finds them.
+
+```bash
+VITE_UMAMI_SRC=https://umami.example.com/script.js
+VITE_UMAMI_WEBSITE_ID=00000000-0000-0000-0000-000000000000
+# Only when the collect API answers on another origin than the script.
+VITE_UMAMI_HOST_URL=
+```
+
+The build reads the same variables to swap the `preconnect` hints in
+`index.html` and to keep the tracker origin out of the service worker cache
+(`vite.config.mts`). If the site is served behind a Content-Security-Policy —
+none is defined in this repository, so it would live in the web server or CDN
+config — the Umami origin has to be allowed in `script-src` and `connect-src`,
+and the Google origins can be dropped once GA is gone.
+
 ## Tech Stack
 
 - Vue 3 (Composition API)

--- a/packages/front/index.html
+++ b/packages/front/index.html
@@ -37,9 +37,14 @@
     <meta name="author" content="GutenKu" />
     <meta name="robots" content="index, follow" />
 
-    <!-- Preconnect for external services -->
+    <!-- Preconnect for external services. The block below is replaced at build
+         time with the origins of the configured analytics provider, and left
+         empty when there is none — see vite.config.mts. The GA hosts are the
+         authored default so the file stands on its own. -->
+    <!-- analytics-preconnect:start -->
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="preconnect" href="https://region1.google-analytics.com" />
+    <!-- analytics-preconnect:end -->
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/packages/front/src/App.vue
+++ b/packages/front/src/App.vue
@@ -6,10 +6,13 @@ import { StatusBar, Style } from '@capacitor/status-bar';
 import PwaInstallBanner from '@/core/components/ui/PwaInstallBanner.vue';
 import CookieConsentBanner from '@/core/components/ui/CookieConsentBanner.vue';
 import { useCookieConsent } from '@/core/composables/cookie-consent';
+import { isAnalyticsEnabled } from '@/services/analytics/config';
 import { isNative, isIOS, platform } from '@/utils/capacitor';
 
 const router = useRouter();
 const { analyticsAllowed, isConsentRequired } = useCookieConsent();
+// No provider configured: loading the chunk would buy nothing but a no-op.
+const analyticsEnabled = isAnalyticsEnabled();
 
 const startAnalytics = () =>
   import('@/services/analytics').then(({ initAnalytics }) =>
@@ -32,7 +35,7 @@ function scheduleAnalytics() {
 // Accepting mid-session takes effect at once, with no reload and no idle wait.
 // Only reachable under a provider that asks; the others start on their own.
 watch(analyticsAllowed, (allowed) => {
-  if (!allowed) {
+  if (!allowed || !analyticsEnabled) {
     return;
   }
 
@@ -66,7 +69,10 @@ onMounted(async () => {
 
   // Analytics is opt-in for as long as the tag needs a cookie. A cookieless,
   // self-hosted provider is asked no question and starts straight away.
-  if (!isConsentRequired.value || analyticsAllowed.value) {
+  if (
+    analyticsEnabled &&
+    (!isConsentRequired.value || analyticsAllowed.value)
+  ) {
     scheduleAnalytics();
   }
 });

--- a/packages/front/src/App.vue
+++ b/packages/front/src/App.vue
@@ -9,7 +9,7 @@ import { useCookieConsent } from '@/core/composables/cookie-consent';
 import { isNative, isIOS, platform } from '@/utils/capacitor';
 
 const router = useRouter();
-const { analyticsAllowed } = useCookieConsent();
+const { analyticsAllowed, isConsentRequired } = useCookieConsent();
 
 const startAnalytics = () =>
   import('@/services/analytics').then(({ initAnalytics }) =>
@@ -30,6 +30,7 @@ function scheduleAnalytics() {
 }
 
 // Accepting mid-session takes effect at once, with no reload and no idle wait.
+// Only reachable under a provider that asks; the others start on their own.
 watch(analyticsAllowed, (allowed) => {
   if (!allowed) {
     return;
@@ -63,8 +64,9 @@ onMounted(async () => {
     }
   }
 
-  // Analytics is opt-in: nothing loads until the visitor has said yes.
-  if (analyticsAllowed.value) {
+  // Analytics is opt-in for as long as the tag needs a cookie. A cookieless,
+  // self-hosted provider is asked no question and starts straight away.
+  if (!isConsentRequired.value || analyticsAllowed.value) {
     scheduleAnalytics();
   }
 });

--- a/packages/front/src/core/components/AppFooter.vue
+++ b/packages/front/src/core/components/AppFooter.vue
@@ -9,8 +9,10 @@ import ThemeToggle from '@/core/components/ThemeToggle.vue';
 import AccessibilityToggle from '@/core/components/AccessibilityToggle.vue';
 import CookieConsentToggle from '@/core/components/CookieConsentToggle.vue';
 import { useLocale } from '@/core/composables/locale';
+import { useCookieConsent } from '@/core/composables/cookie-consent';
 
 const { t } = useI18n();
+const { isConsentRequired } = useCookieConsent();
 const { currentLocale, availableLocales, setLocale, getLocaleLabel } =
   useLocale();
 const currentYear = new Date().getFullYear();
@@ -221,8 +223,9 @@ function openSocialLink(url: string) {
         </div>
         <AccessibilityToggle class="stagger-9" />
         <!-- Consent is a site preference, so it sits with the other
-             preferences rather than beside the copyright. -->
-        <CookieConsentToggle class="stagger-10" />
+             preferences rather than beside the copyright. Gone entirely under a
+             cookieless provider: the control would open an empty question. -->
+        <CookieConsentToggle v-if="isConsentRequired" class="stagger-10" />
       </div>
     </div>
 

--- a/packages/front/src/core/composables/cookie-consent.ts
+++ b/packages/front/src/core/composables/cookie-consent.ts
@@ -1,4 +1,7 @@
 import { computed, readonly, ref } from 'vue';
+// Config only — reading it pulls in no vendor tag, so the analytics chunk stays
+// lazily loaded as before.
+import { isConsentRequired } from '@/services/analytics/config';
 
 export type ConsentStatus = 'undecided' | 'accepted' | 'declined';
 
@@ -117,6 +120,12 @@ function decline(): void {
  * changes their mind twice is never left without one.
  */
 export function openCookieConsent(): void {
+  // A cookieless provider has nothing to ask about: opening would show a banner
+  // whose only outcome is turning off something that was never on.
+  if (!isConsentRequired()) {
+    return;
+  }
+
   hydrate();
   isReopened.value = true;
 }
@@ -124,12 +133,20 @@ export function openCookieConsent(): void {
 export function useCookieConsent() {
   hydrate();
 
+  // Constant for a build — it is derived from the env — but exposed as a
+  // computed so templates and watchers consume it like the rest.
+  const consentRequired = computed(() => isConsentRequired());
+
   return {
     status: readonly(status),
     isDecided: computed(() => status.value !== 'undecided'),
     analyticsAllowed: computed(() => status.value === 'accepted'),
+    /** False under a cookieless provider: no banner, no footer control. */
+    isConsentRequired: consentRequired,
     isBannerVisible: computed(
-      () => isReopened.value || status.value === 'undecided',
+      () =>
+        consentRequired.value &&
+        (isReopened.value || status.value === 'undecided'),
     ),
 
     accept,

--- a/packages/front/src/services/analytics/config.ts
+++ b/packages/front/src/services/analytics/config.ts
@@ -1,0 +1,76 @@
+import { isNative } from '@/utils/capacitor';
+
+/**
+ * Umami self-hosted is cookieless and stores no visitor identifier, so it needs
+ * no consent question. GA does. The mode therefore decides both which tag ships
+ * and whether the cookie banner exists at all.
+ */
+export type AnalyticsMode = 'umami' | 'ga' | 'none';
+
+export interface UmamiConfig {
+  scriptSrc: string;
+  websiteId: string;
+  /** Only when the collect API answers on another origin than the script. */
+  hostUrl?: string;
+}
+
+function text(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function getGaMeasurementId(): string | undefined {
+  return text(import.meta.env.VITE_GA_MEASUREMENT_ID);
+}
+
+/** Undefined unless both halves are set: neither one alone can send a hit. */
+export function getUmamiConfig(): UmamiConfig | undefined {
+  const scriptSrc = text(import.meta.env.VITE_UMAMI_SRC);
+  const websiteId = text(import.meta.env.VITE_UMAMI_WEBSITE_ID);
+
+  if (!scriptSrc || !websiteId) {
+    return undefined;
+  }
+
+  return {
+    scriptSrc,
+    websiteId,
+    hostUrl: text(import.meta.env.VITE_UMAMI_HOST_URL),
+  };
+}
+
+/**
+ * Umami wins over GA when both are configured, so a half-finished migration
+ * measures once rather than twice. Native builds ship through the app stores
+ * and carry no web tag at all.
+ *
+ * Deliberately free of any `document` check: the banner's visibility derives
+ * from this, and vite-ssg prerenders in Node — a mode that changed between the
+ * prerender and the client would make the footer hydrate against a different
+ * tree.
+ */
+export function resolveAnalyticsMode(): AnalyticsMode {
+  if (isNative) {
+    return 'none';
+  }
+
+  if (getUmamiConfig()) {
+    return 'umami';
+  }
+
+  return getGaMeasurementId() ? 'ga' : 'none';
+}
+
+/** False while prerendering: a vendor tag needs a live document to attach to. */
+export function canHostTag(): boolean {
+  return typeof document !== 'undefined';
+}
+
+export function isConsentRequired(): boolean {
+  return resolveAnalyticsMode() === 'ga';
+}

--- a/packages/front/src/services/analytics/config.ts
+++ b/packages/front/src/services/analytics/config.ts
@@ -4,6 +4,9 @@ import { isNative } from '@/utils/capacitor';
  * Umami self-hosted is cookieless and stores no visitor identifier, so it needs
  * no consent question. GA does. The mode therefore decides both which tag ships
  * and whether the cookie banner exists at all.
+ *
+ * It describes what is *configured*, not what will run: whether the runtime can
+ * host a tag at all is the providers' question, answered by canHostTag().
  */
 export type AnalyticsMode = 'umami' | 'ga' | 'none';
 
@@ -46,19 +49,15 @@ export function getUmamiConfig(): UmamiConfig | undefined {
 
 /**
  * Umami wins over GA when both are configured, so a half-finished migration
- * measures once rather than twice. Native builds ship through the app stores
- * and carry no web tag at all.
+ * measures once rather than twice.
  *
- * Deliberately free of any `document` check: the banner's visibility derives
- * from this, and vite-ssg prerenders in Node — a mode that changed between the
- * prerender and the client would make the footer hydrate against a different
- * tree.
+ * Deliberately free of every runtime signal — `document`, the platform — and
+ * derived from the env alone. The footer's cookie control is prerendered from
+ * this, and `cap:build` ships the very `dist` that vite-ssg prerendered in Node
+ * to the app stores: a mode that answered differently on the device would make
+ * the footer hydrate against a different tree.
  */
 export function resolveAnalyticsMode(): AnalyticsMode {
-  if (isNative) {
-    return 'none';
-  }
-
   if (getUmamiConfig()) {
     return 'umami';
   }
@@ -66,9 +65,18 @@ export function resolveAnalyticsMode(): AnalyticsMode {
   return getGaMeasurementId() ? 'ga' : 'none';
 }
 
-/** False while prerendering: a vendor tag needs a live document to attach to. */
+/**
+ * Whether this runtime can host a vendor tag at all: vite-ssg prerenders with
+ * no document to attach one to, and native builds ship through the app stores
+ * rather than the web property.
+ */
 export function canHostTag(): boolean {
-  return typeof document !== 'undefined';
+  return typeof document !== 'undefined' && !isNative;
+}
+
+/** False when nothing is configured — not even a chunk is worth fetching. */
+export function isAnalyticsEnabled(): boolean {
+  return resolveAnalyticsMode() !== 'none';
 }
 
 export function isConsentRequired(): boolean {

--- a/packages/front/src/services/analytics/ga.ts
+++ b/packages/front/src/services/analytics/ga.ts
@@ -1,4 +1,4 @@
-import { isNative } from '@/utils/capacitor';
+import { canHostTag, getGaMeasurementId, resolveAnalyticsMode } from './config';
 import type { AnalyticsProvider, EventParams, PageView } from './types';
 
 type GtagArgs = unknown[];
@@ -7,20 +7,10 @@ const SCRIPT_ID = 'ga-gtag';
 
 let loaded = false;
 
-export function getMeasurementId(): string | undefined {
-  const id = import.meta.env.VITE_GA_MEASUREMENT_ID;
-
-  return typeof id === 'string' && id.length > 0 ? id : undefined;
-}
-
 export function isGaAvailable(): boolean {
-  // vite-ssg prerenders without a document, and native builds ship through the
-  // app stores rather than the web property.
-  if (typeof document === 'undefined' || isNative) {
-    return false;
-  }
-
-  return getMeasurementId() !== undefined;
+  // vite-ssg prerenders without a document to attach the tag to. The mode
+  // covers the rest: unconfigured, a native build, or Umami taking over.
+  return canHostTag() && resolveAnalyticsMode() === 'ga';
 }
 
 /**
@@ -53,7 +43,7 @@ export const gaProvider: AnalyticsProvider = {
       return;
     }
 
-    const id = getMeasurementId();
+    const id = getGaMeasurementId();
 
     if (!id) {
       return;

--- a/packages/front/src/services/analytics/ga.ts
+++ b/packages/front/src/services/analytics/ga.ts
@@ -8,8 +8,8 @@ const SCRIPT_ID = 'ga-gtag';
 let loaded = false;
 
 export function isGaAvailable(): boolean {
-  // vite-ssg prerenders without a document to attach the tag to. The mode
-  // covers the rest: unconfigured, a native build, or Umami taking over.
+  // canHostTag() rules out the prerender and the native builds; the mode covers
+  // the rest: unconfigured, or Umami taking over.
   return canHostTag() && resolveAnalyticsMode() === 'ga';
 }
 

--- a/packages/front/src/services/analytics/index.ts
+++ b/packages/front/src/services/analytics/index.ts
@@ -1,8 +1,11 @@
 import type { RouteLocationNormalized, Router } from 'vue-router';
 import { gaProvider } from './ga';
+import { umamiProvider } from './umami';
 import type { AnalyticsProvider, EventParams, PageView } from './types';
 
-const providers: AnalyticsProvider[] = [gaProvider];
+// At most one is ever available: the mode picks the tag, and Umami wins when
+// both are configured. Listing them here keeps the choice a runtime concern.
+const providers: AnalyticsProvider[] = [umamiProvider, gaProvider];
 
 let started = false;
 let lastPath: string | undefined;
@@ -87,3 +90,5 @@ export function resetAnalyticsForTests(): void {
 }
 
 export type { AnalyticsProvider, EventParams, PageView };
+export { isConsentRequired, resolveAnalyticsMode } from './config';
+export type { AnalyticsMode } from './config';

--- a/packages/front/src/services/analytics/umami.ts
+++ b/packages/front/src/services/analytics/umami.ts
@@ -1,0 +1,136 @@
+import { canHostTag, getUmamiConfig, resolveAnalyticsMode } from './config';
+import type { AnalyticsProvider, EventParams, PageView } from './types';
+
+type UmamiProps = Record<string, unknown>;
+
+interface UmamiTracker {
+  track(payload?: UmamiProps | ((props: UmamiProps) => UmamiProps)): void;
+  track(name: string, data?: EventParams): void;
+}
+
+const SCRIPT_ID = 'umami-tracker';
+
+/**
+ * The tracker script is async, so the entry page view is queued more often than
+ * not. The cap only matters when the script never arrives — a blocked host or a
+ * down instance — where an unbounded queue would grow for the whole session.
+ */
+const MAX_QUEUED_CALLS = 20;
+
+let loaded = false;
+let queue: Array<(tracker: UmamiTracker) => void> = [];
+
+function getTracker(): UmamiTracker | undefined {
+  return (globalThis as { umami?: UmamiTracker }).umami;
+}
+
+export function isUmamiAvailable(): boolean {
+  return canHostTag() && resolveAnalyticsMode() === 'umami';
+}
+
+function send(call: (tracker: UmamiTracker) => void): void {
+  if (!loaded) {
+    return;
+  }
+
+  const tracker = getTracker();
+
+  if (tracker) {
+    call(tracker);
+
+    return;
+  }
+
+  if (queue.length >= MAX_QUEUED_CALLS) {
+    queue.shift();
+  }
+
+  queue.push(call);
+}
+
+function flush(): void {
+  const tracker = getTracker();
+  const pending = queue;
+
+  queue = [];
+
+  if (!tracker) {
+    return;
+  }
+
+  for (const call of pending) {
+    call(tracker);
+  }
+}
+
+export const umamiProvider: AnalyticsProvider = {
+  name: 'umami',
+
+  isAvailable: isUmamiAvailable,
+
+  load(): void {
+    if (loaded || !isUmamiAvailable()) {
+      return;
+    }
+
+    const config = getUmamiConfig();
+
+    if (!config) {
+      return;
+    }
+
+    loaded = true;
+
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.async = true;
+    script.defer = true;
+    script.src = config.scriptSrc;
+    script.dataset.websiteId = config.websiteId;
+    // The router sends page views itself, exactly as it does for GA. Left on,
+    // the tracker would report the entry page a second time on its own.
+    script.dataset.autoTrack = 'false';
+
+    if (config.hostUrl) {
+      script.dataset.hostUrl = config.hostUrl;
+    }
+
+    script.addEventListener('load', flush, { once: true });
+    // An ad blocker or an unreachable instance: drop what was buffered rather
+    // than hold navigations for a tracker that is never coming.
+    script.addEventListener(
+      'error',
+      () => {
+        queue = [];
+      },
+      { once: true },
+    );
+
+    document.head.append(script);
+  },
+
+  trackPageView({ path, title }: PageView): void {
+    send((tracker) => {
+      // The callback form receives the tracker's own props and returns an
+      // override. Passing a bare object instead would drop the website id the
+      // script injected, and the hit would be rejected.
+      tracker.track((props) => ({
+        ...props,
+        url: path,
+        ...(title ? { title } : {}),
+      }));
+    });
+  },
+
+  trackEvent(name: string, params: EventParams = {}): void {
+    send((tracker) => {
+      tracker.track(name, params);
+    });
+  },
+};
+
+/** Test seam: module scope would otherwise leak between cases. */
+export function resetUmamiForTests(): void {
+  loaded = false;
+  queue = [];
+}

--- a/packages/front/src/vite-env.d.ts
+++ b/packages/front/src/vite-env.d.ts
@@ -6,6 +6,9 @@ interface ImportMetaEnv {
   readonly VITE_SERVER_HOST?: string;
   readonly VITE_WEBSOCKET_HOST?: string;
   readonly VITE_GA_MEASUREMENT_ID?: string;
+  readonly VITE_UMAMI_SRC?: string;
+  readonly VITE_UMAMI_WEBSITE_ID?: string;
+  readonly VITE_UMAMI_HOST_URL?: string;
 }
 
 interface ImportMeta {

--- a/packages/front/tests/unit/core/composables/cookie-consent.test.ts
+++ b/packages/front/tests/unit/core/composables/cookie-consent.test.ts
@@ -1,7 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { nextTick, watchEffect } from 'vue';
 
 const STORAGE_KEY = 'gutenku-cookie-consent';
+const MEASUREMENT_ID = 'G-TEST12345';
+const UMAMI_SRC = 'https://stats.example.test/script.js';
+const UMAMI_WEBSITE_ID = '0d1e2f34-5678-49ab-cdef-0123456789ab';
+
+/** The question only exists under a provider that needs a cookie. */
+function useGaMode(): void {
+  vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+  vi.stubEnv('VITE_UMAMI_SRC', '');
+  vi.stubEnv('VITE_UMAMI_WEBSITE_ID', '');
+}
+
+function useUmamiMode(): void {
+  vi.stubEnv('VITE_GA_MEASUREMENT_ID', '');
+  vi.stubEnv('VITE_UMAMI_SRC', UMAMI_SRC);
+  vi.stubEnv('VITE_UMAMI_WEBSITE_ID', UMAMI_WEBSITE_ID);
+}
 
 type ConsentModule = typeof import('@/core/composables/cookie-consent');
 
@@ -37,6 +53,11 @@ describe('cookie consent', () => {
   beforeEach(() => {
     vi.resetModules();
     localStorage.clear();
+    useGaMode();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('starts undecided and keeps analytics off', async () => {
@@ -186,5 +207,54 @@ describe('cookie consent', () => {
     expect(useCookieConsent().status.value).toBe('undecided');
 
     getItem.mockRestore();
+  });
+});
+
+describe('cookie consent under a cookieless provider', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    useUmamiMode();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('never shows the banner', async () => {
+    const { useCookieConsent } = await loadConsent();
+    const consent = useCookieConsent();
+
+    expect(consent.isConsentRequired.value).toBeFalsy();
+    // Nothing was ever asked, so the visitor is still "undecided" — the banner
+    // must stay away all the same.
+    expect(consent.status.value).toBe('undecided');
+    expect(consent.isBannerVisible.value).toBeFalsy();
+  });
+
+  it('ignores a request to reopen the question', async () => {
+    const { useCookieConsent, openCookieConsent } = await loadConsent();
+    const consent = useCookieConsent();
+
+    openCookieConsent();
+    await nextTick();
+
+    // The footer control is hidden in this mode; if anything else reaches
+    // here, an empty banner is the one outcome that must not happen.
+    expect(consent.isBannerVisible.value).toBeFalsy();
+  });
+
+  it('leaves a decision recorded under GA untouched', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, decidedAt: 0, analytics: false }),
+    );
+
+    const { useCookieConsent } = await loadConsent();
+    const consent = useCookieConsent();
+
+    // Nothing is dropped: switching back to GA has to find the old refusal.
+    expect(consent.status.value).toBe('declined');
+    expect(consent.isBannerVisible.value).toBeFalsy();
   });
 });

--- a/packages/front/tests/unit/services/analytics/config.test.ts
+++ b/packages/front/tests/unit/services/analytics/config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT_SRC = 'https://stats.example.test/script.js';
+const WEBSITE_ID = '0d1e2f34-5678-49ab-cdef-0123456789ab';
+const MEASUREMENT_ID = 'G-TEST12345';
+
+async function loadConfig(options: { native?: boolean } = {}) {
+  vi.doMock('@/utils/capacitor', () => ({ isNative: options.native ?? false }));
+
+  return import('@/services/analytics/config');
+}
+
+describe('analytics config', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', '');
+    vi.stubEnv('VITE_UMAMI_SRC', '');
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', '');
+    vi.stubEnv('VITE_UMAMI_HOST_URL', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('falls back to no analytics when nothing is configured', async () => {
+    const { resolveAnalyticsMode, isConsentRequired } = await loadConfig();
+
+    expect(resolveAnalyticsMode()).toBe('none');
+    expect(isConsentRequired()).toBeFalsy();
+  });
+
+  it('asks for consent under GA', async () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+
+    const { resolveAnalyticsMode, isConsentRequired } = await loadConfig();
+
+    expect(resolveAnalyticsMode()).toBe('ga');
+    expect(isConsentRequired()).toBeTruthy();
+  });
+
+  it('asks for nothing under Umami, which sets no cookie', async () => {
+    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', WEBSITE_ID);
+
+    const { resolveAnalyticsMode, isConsentRequired } = await loadConfig();
+
+    expect(resolveAnalyticsMode()).toBe('umami');
+    expect(isConsentRequired()).toBeFalsy();
+  });
+
+  it('lets Umami win over a GA id left behind by the migration', async () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', WEBSITE_ID);
+
+    const { resolveAnalyticsMode } = await loadConfig();
+
+    // Measuring twice is worse than measuring once — and it would keep the
+    // cookie banner alive on a site that no longer needs one.
+    expect(resolveAnalyticsMode()).toBe('umami');
+  });
+
+  it('ignores a half-configured Umami and stays on GA', async () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
+
+    const { resolveAnalyticsMode, getUmamiConfig } = await loadConfig();
+
+    expect(getUmamiConfig()).toBeUndefined();
+    expect(resolveAnalyticsMode()).toBe('ga');
+  });
+
+  it('treats blank-only values as unset', async () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', '   ');
+
+    const { resolveAnalyticsMode } = await loadConfig();
+
+    expect(resolveAnalyticsMode()).toBe('none');
+  });
+
+  it('ships no web tag in a native build', async () => {
+    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', WEBSITE_ID);
+
+    const { resolveAnalyticsMode } = await loadConfig({ native: true });
+
+    expect(resolveAnalyticsMode()).toBe('none');
+  });
+});

--- a/packages/front/tests/unit/services/analytics/config.test.ts
+++ b/packages/front/tests/unit/services/analytics/config.test.ts
@@ -79,12 +79,38 @@ describe('analytics config', () => {
     expect(resolveAnalyticsMode()).toBe('none');
   });
 
-  it('ships no web tag in a native build', async () => {
-    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
-    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', WEBSITE_ID);
+  it('reports whether anything is configured at all', async () => {
+    const unconfigured = await loadConfig();
 
-    const { resolveAnalyticsMode } = await loadConfig({ native: true });
+    expect(unconfigured.isAnalyticsEnabled()).toBeFalsy();
 
-    expect(resolveAnalyticsMode()).toBe('none');
+    vi.resetModules();
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+
+    const configured = await loadConfig();
+
+    expect(configured.isAnalyticsEnabled()).toBeTruthy();
+  });
+
+  it('keeps the mode a build-time answer the platform cannot change', async () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', MEASUREMENT_ID);
+
+    const { resolveAnalyticsMode, canHostTag } = await loadConfig({
+      native: true,
+    });
+
+    // `cap:build` ships the very dist vite-ssg prerendered in Node. A mode that
+    // answered differently on the device would prerender the footer's cookie
+    // control and then hydrate without it.
+    expect(resolveAnalyticsMode()).toBe('ga');
+    // The tag is kept out of native builds here instead, where the providers
+    // read it — nothing the prerendered markup depends on.
+    expect(canHostTag()).toBeFalsy();
+  });
+
+  it('hosts a tag in a browser', async () => {
+    const { canHostTag } = await loadConfig();
+
+    expect(canHostTag()).toBeTruthy();
   });
 });

--- a/packages/front/tests/unit/services/analytics/index.test.ts
+++ b/packages/front/tests/unit/services/analytics/index.test.ts
@@ -23,20 +23,28 @@ function stubRouter(path: string, title?: string): StubRouter {
   };
 }
 
-async function loadAnalytics(available: boolean) {
-  const provider = {
-    name: 'stub',
+function stubProvider(name: string, available: boolean) {
+  return {
+    name,
     isAvailable: vi.fn(() => available),
     load: vi.fn(),
     trackPageView: vi.fn(),
     trackEvent: vi.fn(),
   };
+}
+
+async function loadAnalytics(available: boolean) {
+  const provider = stubProvider('ga', available);
+  // Only one provider is ever available at a time; the other has to be stubbed
+  // out or the real module would read the ambient env.
+  const umami = stubProvider('umami', false);
 
   vi.doMock('@/services/analytics/ga', () => ({ gaProvider: provider }));
+  vi.doMock('@/services/analytics/umami', () => ({ umamiProvider: umami }));
 
   const module = await import('@/services/analytics');
 
-  return { module, provider };
+  return { module, provider, umami };
 }
 
 describe('initAnalytics', () => {
@@ -122,5 +130,27 @@ describe('initAnalytics', () => {
 
     expect(provider.load).not.toHaveBeenCalled();
     expect(provider.trackPageView).not.toHaveBeenCalled();
+  });
+
+  it('reports through the one provider the mode selected', async () => {
+    const ga = stubProvider('ga', false);
+    const umami = stubProvider('umami', true);
+
+    vi.doMock('@/services/analytics/ga', () => ({ gaProvider: ga }));
+    vi.doMock('@/services/analytics/umami', () => ({ umamiProvider: umami }));
+
+    const module = await import('@/services/analytics');
+    const { router } = stubRouter('/haiku', 'Haiku');
+
+    module.initAnalytics(router);
+    module.trackEvent('haiku_generated');
+
+    expect(umami.load).toHaveBeenCalledTimes(1);
+    expect(umami.trackPageView).toHaveBeenCalledTimes(1);
+    expect(umami.trackEvent).toHaveBeenCalledWith('haiku_generated', undefined);
+    // Switching providers must not leave the old tag sending in parallel.
+    expect(ga.load).not.toHaveBeenCalled();
+    expect(ga.trackPageView).not.toHaveBeenCalled();
+    expect(ga.trackEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/front/tests/unit/services/analytics/umami.test.ts
+++ b/packages/front/tests/unit/services/analytics/umami.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT_SRC = 'https://stats.example.test/script.js';
+const WEBSITE_ID = '0d1e2f34-5678-49ab-cdef-0123456789ab';
+
+interface TrackerStub {
+  track: ReturnType<typeof vi.fn>;
+}
+
+async function loadProvider(options: { native?: boolean } = {}) {
+  vi.doMock('@/utils/capacitor', () => ({ isNative: options.native ?? false }));
+
+  return import('@/services/analytics/umami');
+}
+
+function trackerScript(): HTMLScriptElement | null {
+  return document.querySelector<HTMLScriptElement>('script#umami-tracker');
+}
+
+/** Stands in for the async script arriving: the tracker appears, then `load`. */
+function arrive(): TrackerStub {
+  const tracker: TrackerStub = { track: vi.fn() };
+
+  (globalThis as { umami?: TrackerStub }).umami = tracker;
+  trackerScript()?.dispatchEvent(new Event('load'));
+
+  return tracker;
+}
+
+describe('umami provider', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_UMAMI_SRC', SCRIPT_SRC);
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', WEBSITE_ID);
+    vi.stubEnv('VITE_UMAMI_HOST_URL', '');
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', '');
+    document.head.innerHTML = '';
+    delete (globalThis as { umami?: TrackerStub }).umami;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('injects the tracker script exactly once, with auto-track off', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+    umamiProvider.load();
+
+    const tags = document.querySelectorAll('script#umami-tracker');
+
+    expect(tags).toHaveLength(1);
+    expect(trackerScript()?.src).toBe(SCRIPT_SRC);
+    expect(trackerScript()?.dataset.websiteId).toBe(WEBSITE_ID);
+    // The router reports navigations itself; auto-track would double the
+    // entry page.
+    expect(trackerScript()?.dataset.autoTrack).toBe('false');
+    // Unset unless the collect API lives on another origin.
+    expect(trackerScript()?.dataset.hostUrl).toBeUndefined();
+  });
+
+  it('passes a separate collect host through to the script', async () => {
+    vi.stubEnv('VITE_UMAMI_HOST_URL', 'https://collect.example.test');
+
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+
+    expect(trackerScript()?.dataset.hostUrl).toBe(
+      'https://collect.example.test',
+    );
+  });
+
+  it('replays page views buffered before the async script arrived', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+    // The entry route is reported the moment analytics starts, which is almost
+    // always before the tracker has finished downloading.
+    umamiProvider.trackPageView({ path: '/haiku', title: 'Haiku' });
+
+    const tracker = arrive();
+
+    expect(tracker.track).toHaveBeenCalledTimes(1);
+
+    const override = tracker.track.mock.calls[0][0] as (
+      props: Record<string, unknown>,
+    ) => Record<string, unknown>;
+
+    // The callback form keeps the website id the script injected; a bare
+    // object would drop it and the hit would be rejected.
+    expect(override({ website: WEBSITE_ID, url: '/' })).toMatchObject({
+      website: WEBSITE_ID,
+      url: '/haiku',
+      title: 'Haiku',
+    });
+  });
+
+  it('sends straight through once the tracker is present', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+
+    const tracker = arrive();
+
+    umamiProvider.trackEvent('haiku_generated', { source: 'button' });
+
+    expect(tracker.track).toHaveBeenCalledWith('haiku_generated', {
+      source: 'button',
+    });
+  });
+
+  it('drops the queue when the script fails to load', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+    umamiProvider.trackPageView({ path: '/haiku' });
+    // An ad blocker, or an instance that is down.
+    trackerScript()?.dispatchEvent(new Event('error'));
+
+    const tracker = arrive();
+
+    expect(tracker.track).not.toHaveBeenCalled();
+  });
+
+  it('caps the queue so a blocked tracker cannot grow it without bound', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.load();
+
+    for (let index = 0; index < 50; index += 1) {
+      umamiProvider.trackPageView({ path: `/page-${index}` });
+    }
+
+    const tracker = arrive();
+
+    expect(tracker.track.mock.calls.length).toBeLessThanOrEqual(20);
+    expect(tracker.track).toHaveBeenCalled();
+  });
+
+  it('is unavailable and loads nothing when half configured', async () => {
+    vi.stubEnv('VITE_UMAMI_WEBSITE_ID', '');
+
+    const { umamiProvider } = await loadProvider();
+
+    expect(umamiProvider.isAvailable()).toBeFalsy();
+
+    umamiProvider.load();
+
+    expect(document.querySelectorAll('script#umami-tracker')).toHaveLength(0);
+  });
+
+  it('is unavailable inside a native Capacitor build', async () => {
+    const { umamiProvider } = await loadProvider({ native: true });
+
+    expect(umamiProvider.isAvailable()).toBeFalsy();
+
+    umamiProvider.load();
+
+    expect(document.querySelectorAll('script#umami-tracker')).toHaveLength(0);
+  });
+
+  it('drops events when the script was never injected', async () => {
+    const { umamiProvider } = await loadProvider();
+
+    umamiProvider.trackEvent('haiku_generated');
+
+    const tracker = arrive();
+
+    expect(tracker.track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/front/vite.config.mts
+++ b/packages/front/vite.config.mts
@@ -55,6 +55,16 @@ const GA_ORIGINS = [
   'https://region1.google-analytics.com',
 ];
 
+interface AnalyticsOrigins {
+  /** Origins worth a preconnect hint, whoever hosts them. */
+  preconnect: string[];
+  /**
+   * Self-hosted origins only. Kept apart from the GA hosts, which have their
+   * own literal caching rule below and never reach a built pattern.
+   */
+  selfHosted: string[];
+}
+
 /**
  * Mirrors resolveAnalyticsMode() in src/services/analytics/config.ts. The build
  * needs the same answer as the app to know which origins to preconnect and
@@ -64,7 +74,7 @@ const GA_ORIGINS = [
  * which resolves `.env` only: a production build ships `.env.production`, and a
  * hint pointing at the provider that is not the one loading is worse than none.
  */
-function analyticsOrigins(mode: string): string[] {
+function analyticsOrigins(mode: string): AnalyticsOrigins {
   const modeEnv = loadEnv(mode, process.cwd(), ['VITE_']);
   const umamiScriptSrc = modeEnv.VITE_UMAMI_SRC?.trim() || '';
   const umamiWebsiteId = modeEnv.VITE_UMAMI_WEBSITE_ID?.trim() || '';
@@ -72,12 +82,28 @@ function analyticsOrigins(mode: string): string[] {
 
   if (umamiScriptSrc && umamiWebsiteId) {
     // Deduplicated: script and collect API usually share a single origin.
-    return [
+    const origins = [
       ...new Set([originOf(umamiScriptSrc), originOf(umamiHostUrl)]),
     ].filter((origin): origin is string => Boolean(origin));
+
+    return { preconnect: origins, selfHosted: origins };
   }
 
-  return modeEnv.VITE_GA_MEASUREMENT_ID?.trim() ? GA_ORIGINS : [];
+  return {
+    preconnect: modeEnv.VITE_GA_MEASUREMENT_ID?.trim() ? GA_ORIGINS : [],
+    selfHosted: [],
+  };
+}
+
+/**
+ * Matches an origin and everything under it. Every metacharacter is escaped,
+ * the dots of the hostname included: left bare, `stats.example.com` would also
+ * match `statsXexample.com` — an origin somebody else can register.
+ */
+function originPrefixPattern(origin: string): RegExp {
+  const escaped = origin.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+
+  return new RegExp(`^${escaped}/`);
 }
 
 const gutenguessBasePath =
@@ -102,10 +128,6 @@ const vendorChunks: Record<string, string[]> = {
 
 export default defineConfig(({ isSsrBuild, mode }) => {
   const trackerOrigins = analyticsOrigins(mode);
-  // GA's own hosts are already covered by a static rule below.
-  const selfHostedOrigins = trackerOrigins.filter(
-    (origin) => !GA_ORIGINS.includes(origin),
-  );
 
   return {
     plugins: [
@@ -121,7 +143,7 @@ export default defineConfig(({ isSsrBuild, mode }) => {
         // that no longer talks to it — and none at all to the one it does.
         name: 'analytics-preconnect',
         transformIndexHtml(html) {
-          const links = trackerOrigins
+          const links = trackerOrigins.preconnect
             .map((origin) => `<link rel="preconnect" href="${origin}" />`)
             .join('\n    ');
 
@@ -170,17 +192,18 @@ export default defineConfig(({ isSsrBuild, mode }) => {
             {
               // Never cache the tag or its beacons: a stale gtag.js or a replayed
               // /g/collect would corrupt the data it is meant to report.
+              // The subdomain group is optional as a whole: `[a-z0-9-]*\.?`
+              // would also match `evilgoogle-analytics.com`, a host anyone can
+              // register.
               urlPattern:
-                /^https:\/\/(www\.googletagmanager\.com|[a-z0-9-]*\.?google-analytics\.com)\/.*/,
+                /^https:\/\/(www\.googletagmanager\.com|(?:[a-z0-9-]+\.)?google-analytics\.com)\//,
               handler: 'NetworkOnly',
             },
             // Same reasoning for the self-hosted tracker: script.js is expected to
             // be replaceable on the server, and /api/send must never be replayed
             // from a cache.
-            ...selfHostedOrigins.map((origin) => ({
-              urlPattern: new RegExp(
-                `^${origin.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}/.*`,
-              ),
+            ...trackerOrigins.selfHosted.map((origin) => ({
+              urlPattern: originPrefixPattern(origin),
               handler: 'NetworkOnly' as const,
             })),
           ],

--- a/packages/front/vite.config.mts
+++ b/packages/front/vite.config.mts
@@ -73,6 +73,10 @@ interface AnalyticsOrigins {
  * Read with the build's own mode rather than the module-scope `env` above,
  * which resolves `.env` only: a production build ships `.env.production`, and a
  * hint pointing at the provider that is not the one loading is worse than none.
+ *
+ * Like resolveAnalyticsMode(), it reads the env and nothing else. `cap:build`
+ * ships this very `dist` to the app stores, so there is no build-time answer to
+ * which platform will run it.
  */
 function analyticsOrigins(mode: string): AnalyticsOrigins {
   const modeEnv = loadEnv(mode, process.cwd(), ['VITE_']);

--- a/packages/front/vite.config.mts
+++ b/packages/front/vite.config.mts
@@ -40,6 +40,46 @@ function getBlogSlugs(): string[] {
   return [...slugs];
 }
 
+function originOf(url: string): string | undefined {
+  try {
+    return new URL(url).origin;
+  } catch {
+    // A relative script src — same origin, so nothing to preconnect to and the
+    // app's own caching rules already apply.
+    return undefined;
+  }
+}
+
+const GA_ORIGINS = [
+  'https://www.googletagmanager.com',
+  'https://region1.google-analytics.com',
+];
+
+/**
+ * Mirrors resolveAnalyticsMode() in src/services/analytics/config.ts. The build
+ * needs the same answer as the app to know which origins to preconnect and
+ * which ones must never be served from the service worker cache.
+ *
+ * Read with the build's own mode rather than the module-scope `env` above,
+ * which resolves `.env` only: a production build ships `.env.production`, and a
+ * hint pointing at the provider that is not the one loading is worse than none.
+ */
+function analyticsOrigins(mode: string): string[] {
+  const modeEnv = loadEnv(mode, process.cwd(), ['VITE_']);
+  const umamiScriptSrc = modeEnv.VITE_UMAMI_SRC?.trim() || '';
+  const umamiWebsiteId = modeEnv.VITE_UMAMI_WEBSITE_ID?.trim() || '';
+  const umamiHostUrl = modeEnv.VITE_UMAMI_HOST_URL?.trim() || '';
+
+  if (umamiScriptSrc && umamiWebsiteId) {
+    // Deduplicated: script and collect API usually share a single origin.
+    return [
+      ...new Set([originOf(umamiScriptSrc), originOf(umamiHostUrl)]),
+    ].filter((origin): origin is string => Boolean(origin));
+  }
+
+  return modeEnv.VITE_GA_MEASUREMENT_ID?.trim() ? GA_ORIGINS : [];
+}
+
 const gutenguessBasePath =
   env.GUTENGUESS_PATH ||
   resolve(dirname(fileURLToPath(import.meta.url)), '../../private/gutenguess');
@@ -60,125 +100,160 @@ const vendorChunks: Record<string, string[]> = {
   icons: ['@lucide/vue'],
 };
 
-export default defineConfig(({ isSsrBuild }) => ({
-  plugins: [
-    {
-      name: 'html-url-transform',
-      transformIndexHtml(html) {
-        return html.replaceAll('https://gutenku.xyz', siteUrl);
+export default defineConfig(({ isSsrBuild, mode }) => {
+  const trackerOrigins = analyticsOrigins(mode);
+  // GA's own hosts are already covered by a static rule below.
+  const selfHostedOrigins = trackerOrigins.filter(
+    (origin) => !GA_ORIGINS.includes(origin),
+  );
+
+  return {
+    plugins: [
+      {
+        name: 'html-url-transform',
+        transformIndexHtml(html) {
+          return html.replaceAll('https://gutenku.xyz', siteUrl);
+        },
       },
-    },
-    vue(),
-    VueI18nPlugin({
-      include: resolve(
-        dirname(fileURLToPath(import.meta.url)),
-        './src/locales/*.json',
-      ),
-      strictMessage: false,
-    }),
-    viteCompression(),
-    viteImagemin(),
-    webfontDownload(),
-    visualizer({
-      filename: 'dist/bundle-stats.html',
-      gzipSize: true,
-      brotliSize: true,
-    }),
-    VitePWA({
-      registerType: 'autoUpdate',
-      workbox: {
-        skipWaiting: true,
-        clientsClaim: true,
-        globPatterns: ['**/*.{js,css,ico,png,webp,woff2}'],
-        globIgnores: ['**/bundle-stats.html'],
-        navigateFallback: undefined,
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/.*\.webp$/,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'cover-images',
-              expiration: {
-                maxEntries: 100,
-                maxAgeSeconds: 60 * 60 * 24 * 30,
+      {
+        // The hints have to follow the configured provider: left as authored,
+        // they would open a connection to Google on every page load of a site
+        // that no longer talks to it — and none at all to the one it does.
+        name: 'analytics-preconnect',
+        transformIndexHtml(html) {
+          const links = trackerOrigins
+            .map((origin) => `<link rel="preconnect" href="${origin}" />`)
+            .join('\n    ');
+
+          return html.replace(
+            /<!-- analytics-preconnect:start -->[\s\S]*?<!-- analytics-preconnect:end -->/,
+            links,
+          );
+        },
+      },
+      vue(),
+      VueI18nPlugin({
+        include: resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          './src/locales/*.json',
+        ),
+        strictMessage: false,
+      }),
+      viteCompression(),
+      viteImagemin(),
+      webfontDownload(),
+      visualizer({
+        filename: 'dist/bundle-stats.html',
+        gzipSize: true,
+        brotliSize: true,
+      }),
+      VitePWA({
+        registerType: 'autoUpdate',
+        workbox: {
+          skipWaiting: true,
+          clientsClaim: true,
+          globPatterns: ['**/*.{js,css,ico,png,webp,woff2}'],
+          globIgnores: ['**/bundle-stats.html'],
+          navigateFallback: undefined,
+          runtimeCaching: [
+            {
+              urlPattern: /^https:\/\/.*\.webp$/,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'cover-images',
+                expiration: {
+                  maxEntries: 100,
+                  maxAgeSeconds: 60 * 60 * 24 * 30,
+                },
               },
             },
-          },
-          {
-            // Never cache the tag or its beacons: a stale gtag.js or a replayed
-            // /g/collect would corrupt the data it is meant to report.
-            urlPattern:
-              /^https:\/\/(www\.googletagmanager\.com|[a-z0-9-]*\.?google-analytics\.com)\/.*/,
-            handler: 'NetworkOnly',
-          },
-        ],
-      },
-      manifest: false,
-    }),
-  ],
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: isSsrBuild
-          ? undefined
-          : (id) => {
-              for (const [chunkName, modules] of Object.entries(vendorChunks)) {
-                if (
-                  modules.some((mod) => id.includes(`/node_modules/${mod}/`))
-                ) {
-                  return chunkName;
-                }
-              }
+            {
+              // Never cache the tag or its beacons: a stale gtag.js or a replayed
+              // /g/collect would corrupt the data it is meant to report.
+              urlPattern:
+                /^https:\/\/(www\.googletagmanager\.com|[a-z0-9-]*\.?google-analytics\.com)\/.*/,
+              handler: 'NetworkOnly',
             },
+            // Same reasoning for the self-hosted tracker: script.js is expected to
+            // be replaceable on the server, and /api/send must never be replayed
+            // from a cache.
+            ...selfHostedOrigins.map((origin) => ({
+              urlPattern: new RegExp(
+                `^${origin.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}/.*`,
+              ),
+              handler: 'NetworkOnly' as const,
+            })),
+          ],
+        },
+        manifest: false,
+      }),
+    ],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: isSsrBuild
+            ? undefined
+            : (id) => {
+                for (const [chunkName, modules] of Object.entries(
+                  vendorChunks,
+                )) {
+                  if (
+                    modules.some((mod) => id.includes(`/node_modules/${mod}/`))
+                  ) {
+                    return chunkName;
+                  }
+                }
+              },
+        },
       },
     },
-  },
-  define: { 'process.env': {} },
-  resolve: {
-    alias: {
-      '@/features/game': gameModulePath,
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      '@content': fileURLToPath(new URL('./content', import.meta.url)),
+    define: { 'process.env': {} },
+    resolve: {
+      alias: {
+        '@/features/game': gameModulePath,
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@content': fileURLToPath(new URL('./content', import.meta.url)),
+      },
+      extensions: ['.js', '.json', '.jsx', '.mjs', '.ts', '.tsx', '.vue'],
+      dedupe: [
+        'vue',
+        'pinia',
+        'vue-router',
+        'vue-i18n',
+        '@urql/vue',
+        'graphql',
+        '@vueuse/core',
+        '@vueuse/motion',
+        '@lucide/vue',
+        '@unhead/vue',
+      ],
     },
-    extensions: ['.js', '.json', '.jsx', '.mjs', '.ts', '.tsx', '.vue'],
-    dedupe: [
-      'vue',
-      'pinia',
-      'vue-router',
-      'vue-i18n',
-      '@urql/vue',
-      'graphql',
-      '@vueuse/core',
-      '@vueuse/motion',
-      '@lucide/vue',
-      '@unhead/vue',
-    ],
-  },
-  css: {
-    preprocessorOptions: {
-      sass: {
-        api: 'modern-compiler',
-      } as Record<string, unknown>,
-      scss: {
-        api: 'modern-compiler',
-      } as Record<string, unknown>,
+    css: {
+      preprocessorOptions: {
+        sass: {
+          api: 'modern-compiler',
+        } as Record<string, unknown>,
+        scss: {
+          api: 'modern-compiler',
+        } as Record<string, unknown>,
+      },
     },
-  },
-  server: {
-    port: 4444,
-  },
-  ssgOptions: {
-    script: 'async',
-    formatting: 'minify',
-    beastiesOptions: {
-      preload: 'media',
+    server: {
+      port: 4444,
     },
-    includedRoutes(paths) {
-      const blogSlugs = getBlogSlugs();
-      const blogRoutes = blogSlugs.map((slug) => `/blog/${slug}`);
-      const ssgRoutes = ['/', '/haiku', '/blog', '/game', ...blogRoutes];
+    ssgOptions: {
+      script: 'async',
+      formatting: 'minify',
+      beastiesOptions: {
+        preload: 'media',
+      },
+      includedRoutes(paths) {
+        const blogSlugs = getBlogSlugs();
+        const blogRoutes = blogSlugs.map((slug) => `/blog/${slug}`);
+        const ssgRoutes = ['/', '/haiku', '/blog', '/game', ...blogRoutes];
 
-      return [...new Set([...paths, ...ssgRoutes])];
+        return [...new Set([...paths, ...ssgRoutes])];
+      },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
Umami sets no cookie and stores no visitor identifier, so the mode that runs it needs no consent question: the banner and the footer's cookie control are not rendered at all, and analytics starts without waiting for a decision.

The provider is chosen from the env alone, by a config module that carries no vendor code so the analytics chunk stays lazily loaded. Umami wins when both are configured, so a half-finished migration measures once rather than twice, and a decision already stored under GA is left untouched.

The build reads the same variables to swap the preconnect hints and to keep the tracker origin out of the service worker cache. It resolves them with the build's own mode rather than `.env` alone, which a production build does not ship — a hint pointing at the provider that is not loading is worse than none.

Production stays on GA; the Umami variables ship empty.

## Configuration

| Mode | Env | Cookie banner |
| --- | --- | --- |
| `none` | nothing set | none |
| `ga` | `VITE_GA_MEASUREMENT_ID` | shown |
| `umami` | `VITE_UMAMI_SRC` **and** `VITE_UMAMI_WEBSITE_ID` | none |

`VITE_UMAMI_HOST_URL` is optional, for when the collect API answers on another origin than the script.

The mode is read from the env and nothing else. `cap:build` ships the very `dist` that vite-ssg prerendered, so an answer varying by platform would prerender a footer control the device then hydrates without. Native builds load no web tag all the same — `canHostTag()` rules that out where only the providers read it.

## Verified

388 unit tests (3 new files), lint, stylelint, typecheck, and a production build in both modes:

| | preconnect | service worker rule | consent toggle prerendered |
| --- | --- | --- | --- |
| GA | googletagmanager + google-analytics | gtag | present |
| Umami | the Umami origin only | Umami + gtag | absent |

## Follow-ups from review

- Two CodeQL alerts (`js/incomplete-hostname-regexp`): the GA origin literals reached a constructed pattern through a shared return value, kept apart only by a filter. The return is now split into the origins to preconnect and the self-hosted ones a pattern is built for, so the path is gone rather than guarded. The pre-existing GA rule's subdomain group was tightened too — `[a-z0-9-]*\.?` also matched `evilgoogle-analytics.com`.
- The mode no longer varies by platform (above), which also drops the analytics chunk fetch on builds with nothing configured.

## Not in this PR

No Content-Security-Policy is defined in this repository. If one is applied by the web server or CDN, the Umami origin needs `script-src` and `connect-src`, and the Google origins can be dropped once GA is gone.