### PR TITLE
fix(haiku): restore black marker on new haiku and sharpen its render

### DIFF
--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -37,7 +37,7 @@
     "@capacitor/share": "^8.0.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
-    "@chenglou/pretext": "^0.0.7",
+    "@chenglou/pretext": "^0.0.8",
     "@fingerprintjs/botd": "^2.0.0",
     "@gutenku/shared": "workspace:*",
     "@lucide/vue": "^1.0.0",

--- a/packages/front/src/features/haiku/components/HaikuChapter.vue
+++ b/packages/front/src/features/haiku/components/HaikuChapter.vue
@@ -169,6 +169,17 @@ watch(isBot, (botDetected) => {
   }
 });
 
+// Every haiku is a fresh puzzle: re-arm the redaction when one arrives, so a
+// previous reveal does not leak the next chapter. Bots keep the text readable.
+watch(haiku, () => {
+  if (isBot.value) {
+    return;
+  }
+
+  spotlight.value = null;
+  blackMarker.value = true;
+});
+
 onMounted(async () => {
   detectBot();
   applyToAllHighlights();
@@ -351,7 +362,6 @@ onUnmounted(() => {
           :hidden="blackMarker"
           :delay="0"
           :spotlight="spotlight"
-          centered
         />
       </h2>
 
@@ -371,7 +381,6 @@ onUnmounted(() => {
           :hidden="blackMarker"
           :delay="200"
           :spotlight="spotlight"
-          centered
         />
       </div>
 
@@ -1063,7 +1072,10 @@ onUnmounted(() => {
           background-repeat: no-repeat !important;
           background-position: center !important;
           color: var(--gutenku-highlighter-text, #2c2c2c) !important;
+          // Negative margin cancels the padding's advance width, so revealing
+          // a verse never re-flows the pretext-measured line it sits on
           padding: 2px 8px;
+          margin: 0 -8px;
           border-radius: 0;
           font-weight: bold;
           position: relative;
@@ -1085,7 +1097,10 @@ onUnmounted(() => {
           background-repeat: no-repeat !important;
           background-position: center !important;
           color: var(--gutenku-highlighter-text, #2c2c2c) !important;
+          // Negative margin cancels the padding's advance width, so revealing
+          // a verse never re-flows the pretext-measured line it sits on
           padding: 2px 8px;
+          margin: 0 -8px;
           border-radius: 0;
           font-weight: bold;
           position: relative;

--- a/packages/front/src/features/haiku/components/MarkerOverlay.vue
+++ b/packages/front/src/features/haiku/components/MarkerOverlay.vue
@@ -1,9 +1,8 @@
 <script lang="ts" setup>
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
-import type { MarkerLine } from '@/features/haiku/composables/marker-layout';
 import {
-  generateMarkerStrokes,
+  generateMarkerStroke,
   type MarkerStroke,
 } from '@/features/haiku/composables/marker-svg';
 
@@ -15,35 +14,114 @@ const props = withDefaults(
     hidden: boolean;
     /** Base animation delay in ms (for cascading across sections) */
     delay?: number;
-    /** Whether text is centered (title/author) */
-    centered?: boolean;
     /** Cursor position relative to .book-content for spotlight reveal */
     spotlight?: { x: number; y: number } | null;
   }>(),
   {
     delay: 0,
-    centered: false,
     spotlight: null,
   },
 );
 
 const containerRef = ref<HTMLElement | null>(null);
 
-// DOM-based layout: count lines from parent's actual rendered height.
-// Correctly handles CSS text-transform, letter-spacing, etc.
-interface SimpleLayout {
-  lines: MarkerLine[];
+/** One rendered line box of the parent's text */
+interface TextLineBox {
+  /** X offset from the parent's padding box (px) */
+  x: number;
+  /** Y offset from the parent's padding box (px) */
+  y: number;
+  /** Measured width of the text on this line (px) */
+  width: number;
+  /** Measured height of the text on this line (px) */
+  height: number;
+  index: number;
+}
+
+interface OverlayLayout {
+  lines: TextLineBox[];
   containerWidth: number;
   containerHeight: number;
 }
 
-const layout = ref<SimpleLayout>({
+const layout = ref<OverlayLayout>({
   lines: [],
   containerWidth: 0,
   containerHeight: 0,
 });
 const ready = ref(false);
 let resizeObserver: ResizeObserver | null = null;
+
+/**
+ * Measures the parent's rendered text runs with a DOM Range. Unlike dividing
+ * the height by the line height, this yields the real per-line box — so a
+ * centered title gets a bar that hugs the words instead of spanning the whole
+ * page, and text-transform / letter-spacing are accounted for for free.
+ * Nested runs count too, or a wrapper like the author's "by" would stay legible.
+ */
+function measureTextLines(
+  parent: HTMLElement,
+  overlay: HTMLElement,
+): DOMRect[] {
+  const rects: DOMRect[] = [];
+  const range = document.createRange();
+  const walker = document.createTreeWalker(parent, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.textContent?.trim() && !overlay.contains(node)
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT,
+  });
+
+  while (walker.nextNode()) {
+    range.selectNodeContents(walker.currentNode);
+    rects.push(...range.getClientRects());
+  }
+
+  return rects.filter((rect) => rect.width > 0 && rect.height > 0);
+}
+
+/** Groups raw client rects into one box per rendered line */
+function groupIntoLines(
+  rects: DOMRect[],
+  originX: number,
+  originY: number,
+): TextLineBox[] {
+  const rows: Array<{
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+  }> = [];
+
+  // Runs on the same visual line can differ in height (a smaller "by" prefix),
+  // so rows are merged on vertical overlap rather than on an exact top match.
+  for (const rect of [...rects].sort((a, b) => a.top - b.top)) {
+    const row = rows.at(-1);
+
+    if (row && rect.top < row.bottom - 2) {
+      row.left = Math.min(row.left, rect.left);
+      row.right = Math.max(row.right, rect.right);
+      row.top = Math.min(row.top, rect.top);
+      row.bottom = Math.max(row.bottom, rect.bottom);
+
+      continue;
+    }
+    rows.push({
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      bottom: rect.bottom,
+    });
+  }
+
+  return rows.map((row, index) => ({
+    x: row.left - originX,
+    y: row.top - originY,
+    width: row.right - row.left,
+    height: row.bottom - row.top,
+    index,
+  }));
+}
 
 function computeLayout() {
   const el = containerRef.value;
@@ -58,29 +136,23 @@ function computeLayout() {
   }
 
   const style = getComputedStyle(parent);
-  const lineHeight =
-    Number.parseFloat(style.lineHeight) ||
-    Number.parseFloat(style.fontSize) * 1.8;
-  const containerWidth = parent.clientWidth;
-  const contentHeight = parent.scrollHeight;
-  const lineCount = Math.max(1, Math.round(contentHeight / lineHeight));
+  const parentRect = parent.getBoundingClientRect();
+  // .marker-overlay is inset:0 inside the parent, i.e. anchored to its padding box
+  const lines = groupIntoLines(
+    measureTextLines(parent, el),
+    parentRect.left + (Number.parseFloat(style.borderLeftWidth) || 0),
+    parentRect.top + (Number.parseFloat(style.borderTopWidth) || 0),
+  );
 
-  const lines: MarkerLine[] = [];
-
-  for (let i = 0; i < lineCount; i++) {
-    lines.push({
-      x: 0,
-      y: i * lineHeight,
-      width: containerWidth,
-      lineHeight,
-      index: i,
-      isLastLine: i === lineCount - 1,
-      text: '',
-      cutouts: [],
-    });
+  if (!lines.length) {
+    return;
   }
 
-  layout.value = { lines, containerWidth, containerHeight: contentHeight };
+  layout.value = {
+    lines,
+    containerWidth: parent.clientWidth,
+    containerHeight: parent.scrollHeight,
+  };
   ready.value = true;
 }
 
@@ -109,13 +181,23 @@ onUnmounted(() => {
   resizeObserver?.disconnect();
 });
 
-const strokes = computed<MarkerStroke[]>(() => {
-  if (!layout.value.lines.length || !layout.value.containerWidth) {
-    return [];
-  }
+/** Bar bleeds a little past the glyphs on each side, like a real pen pass */
+const TEXT_BLEED = 6;
+/**
+ * Client rects hug the glyph box, so the stroke is generated against a
+ * slightly taller virtual line box and then re-centred on the text.
+ */
+const BOX_SCALE = 1.5;
 
-  return generateMarkerStrokes(layout.value.lines, layout.value.containerWidth);
-});
+const strokes = computed<MarkerStroke[]>(() =>
+  layout.value.lines.map((line) =>
+    generateMarkerStroke({
+      extent: line.width + TEXT_BLEED * 2,
+      lineHeight: line.height * BOX_SCALE,
+      seed: 42 + line.index * 7919,
+    }),
+  ),
+);
 
 // Track animation state
 const hasDrawn = ref(false);
@@ -190,18 +272,13 @@ watch(ready, (isReady) => {
   }
 });
 
-function getLineStyle(line: MarkerLine, stroke: MarkerStroke, index: number) {
-  // For centered text, center the stroke within the container
-  const xPos = props.centered
-    ? (layout.value.containerWidth - stroke.width) / 2
-    : stroke.xOffset;
-
+function getLineStyle(line: TextLineBox, stroke: MarkerStroke, index: number) {
   return {
     '--draw-delay': `${props.delay + index * DRAW_STAGGER}ms`,
     '--draw-duration': `${DRAW_DURATION}ms`,
     '--reveal-delay': `${(totalLines.value - 1 - index) * REVEAL_STAGGER}ms`,
     '--reveal-duration': `${REVEAL_DURATION}ms`,
-    transform: `translate(${xPos}px, ${line.y + stroke.yOffset}px) rotate(${stroke.rotation}deg)`,
+    transform: `translate(${line.x - TEXT_BLEED + stroke.xOffset}px, ${line.y - (line.height * (BOX_SCALE - 1)) / 2 + stroke.yOffset}px) rotate(${stroke.rotation}deg)`,
   };
 }
 </script>

--- a/packages/front/src/features/haiku/components/PretextChapter.vue
+++ b/packages/front/src/features/haiku/components/PretextChapter.vue
@@ -8,12 +8,8 @@ import {
 import {
   generateAllLineSegments,
   type BarSegment,
+  type VerseCutout,
 } from '@/features/haiku/composables/marker-svg';
-
-interface TextSegment {
-  text: string;
-  isVerse: boolean;
-}
 
 const props = withDefaults(
   defineProps<{
@@ -35,6 +31,63 @@ const versesRef = toRef(props, 'verses');
 
 const { layout, ready } = useMarkerLayout(containerRef, textRef, versesRef);
 
+// --- Verse cutouts, measured from the rendered <mark> boxes ---
+//
+// Pretext gives us the line breaks; the browser then justifies each line,
+// stretching the spaces. Reading the cutouts back off the DOM is the only
+// way to land the bar edges exactly on the verse, whatever justification,
+// font synthesis or letter-spacing did to it.
+
+/** Breathing room between a bar end and the verse it stops at (px) */
+const CUTOUT_PAD = 4;
+
+const cutouts = ref<VerseCutout[][]>([]);
+
+function measureCutouts() {
+  const el = containerRef.value;
+
+  if (!el || !layout.value.lines.length) {
+    cutouts.value = [];
+
+    return;
+  }
+
+  const lineEls = el.querySelectorAll<HTMLElement>('.text-line');
+
+  cutouts.value = layout.value.lines.map((_line, index) => {
+    const lineEl = lineEls[index];
+
+    if (!lineEl) {
+      return [];
+    }
+    const lineRect = lineEl.getBoundingClientRect();
+
+    if (!lineRect.width) {
+      return [];
+    }
+
+    return [...lineEl.querySelectorAll('mark')].map((markEl) => {
+      const rect = markEl.getBoundingClientRect();
+      // Discount the highlight's own padding: it differs between the redacted
+      // and revealed styles, and the window belongs to the glyphs, not the box
+      const markStyle = getComputedStyle(markEl);
+      const padLeft = Number.parseFloat(markStyle.paddingLeft) || 0;
+      const padRight = Number.parseFloat(markStyle.paddingRight) || 0;
+
+      return {
+        startX: rect.left - lineRect.left + padLeft - CUTOUT_PAD,
+        endX: rect.right - lineRect.left - padRight + CUTOUT_PAD,
+      };
+    });
+  });
+}
+
+watch(
+  () => layout.value,
+  () => nextTick(measureCutouts),
+  { immediate: true },
+);
+
 // --- Bar segments (split around verse cutouts) ---
 
 const barSegments = computed<BarSegment[][]>(() => {
@@ -45,6 +98,7 @@ const barSegments = computed<BarSegment[][]>(() => {
   return generateAllLineSegments(
     layout.value.lines,
     layout.value.containerWidth,
+    cutouts.value,
   );
 });
 
@@ -65,84 +119,6 @@ const allSegments = computed(() => {
 
   return result;
 });
-
-// --- Verse segmentation (handles verses spanning multiple lines) ---
-
-const verseSegments = computed(() => {
-  const lines = layout.value.lines;
-
-  if (!lines.length) {return [];}
-
-  // Join all line texts; trimEnd avoids double spaces from pretext trailing whitespace
-  const lineOffsets: number[] = [];
-  const lineLengths: number[] = [];
-  let joined = '';
-
-  for (const line of lines) {
-    const trimmed = line.text.trimEnd();
-    lineOffsets.push(joined.length);
-    lineLengths.push(trimmed.length);
-    joined += trimmed + ' ';
-  }
-
-  // Find all verse ranges in the joined text
-  const verseRanges: Array<{ start: number; end: number }> = [];
-
-  for (const verse of props.verses) {
-    if (!verse || !verse.trim()) {continue;}
-    const idx = joined.indexOf(verse.trim());
-
-    if (idx !== -1) {
-      verseRanges.push({ start: idx, end: idx + verse.trim().length });
-    }
-  }
-
-  // For each line, split text into verse/non-verse segments
-  return lines.map((line, li) => {
-    const lineStart = lineOffsets[li];
-    const lineEnd = lineStart + lineLengths[li];
-
-    const overlaps: Array<{ from: number; to: number }> = [];
-
-    for (const vr of verseRanges) {
-      if (vr.start < lineEnd && vr.end > lineStart) {
-        overlaps.push({
-          from: Math.max(0, vr.start - lineStart),
-          to: Math.min(line.text.length, vr.end - lineStart),
-        });
-      }
-    }
-
-    if (!overlaps.length) {
-      return [{ text: line.text, isVerse: false } as TextSegment];
-    }
-
-    overlaps.sort((a, b) => a.from - b.from);
-    const segments: TextSegment[] = [];
-    let cursor = 0;
-
-    for (const ov of overlaps) {
-      if (ov.from > cursor) {
-        segments.push({
-          text: line.text.slice(cursor, ov.from),
-          isVerse: false,
-        });
-      }
-      segments.push({ text: line.text.slice(ov.from, ov.to), isVerse: true });
-      cursor = ov.to;
-    }
-
-    if (cursor < line.text.length) {
-      segments.push({ text: line.text.slice(cursor), isVerse: false });
-    }
-
-    return segments;
-  });
-});
-
-function lineHasVerse(index: number): boolean {
-  return verseSegments.value[index]?.some((s) => s.isVerse) ?? false;
-}
 
 // --- Accessibility ---
 
@@ -261,19 +237,13 @@ function getSegmentStyle(line: MarkerLine, seg: BarSegment, lineIndex: number) {
           width: layout.containerWidth + 'px',
         }"
         ><!--
-        --><template v-if="lineHasVerse(i)"
+        --><template v-for="(seg, si) in line.segments" :key="si"
           ><!--
-          --><template v-for="(seg, si) in verseSegments[i]" :key="si"
-            ><!--
-            --><mark v-if="seg.isVerse" class="highlight">{{ seg.text }}</mark
-            ><!--
-            --><template v-else>{{ seg.text }}</template
-            ><!--
-          --></template
+          --><mark v-if="seg.isVerse" class="highlight">{{ seg.text }}</mark
+          ><!--
+          --><template v-else>{{ seg.text }}</template
           ><!--
         --></template
-        ><!--
-        --><template v-else>{{ line.text }}</template
         ><!--
       --></span>
 

--- a/packages/front/src/features/haiku/composables/marker-layout.ts
+++ b/packages/front/src/features/haiku/composables/marker-layout.ts
@@ -2,18 +2,23 @@ import { ref, watch, onMounted, onUnmounted, type Ref, nextTick } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 
 export interface VerseCutout {
-  /** Pixel X where verse starts within the line */
+  /** Pixel X where the clear window starts within the line */
   startX: number;
-  /** Pixel X where verse ends within the line */
+  /** Pixel X where the clear window ends within the line */
   endX: number;
 }
 
+export interface LineSegment {
+  /** Text content of this run */
+  text: string;
+  /** Whether this run is part of a haiku verse (rendered bold, never redacted) */
+  isVerse: boolean;
+}
+
 export interface MarkerLine {
-  /** X offset from container left edge (px) */
-  x: number;
   /** Y offset from container top edge (px) */
   y: number;
-  /** Measured text width on this line (px) */
+  /** Natural (pre-justification) text width on this line (px) */
   width: number;
   /** Line height (px) */
   lineHeight: number;
@@ -21,10 +26,8 @@ export interface MarkerLine {
   index: number;
   /** Whether this is the last line of its paragraph (left-aligned, not justified) */
   isLastLine: boolean;
-  /** The text content of this line */
-  text: string;
-  /** Verse cutouts — regions where marker bars should NOT render */
-  cutouts: VerseCutout[];
+  /** Verse / non-verse runs making up this line, in reading order */
+  segments: LineSegment[];
 }
 
 export interface MarkerLayoutResult {
@@ -33,22 +36,28 @@ export interface MarkerLayoutResult {
   containerHeight: number;
 }
 
-let pretextModule: typeof import('@chenglou/pretext') | null = null;
+type PretextRichInline = typeof import('@chenglou/pretext/rich-inline');
 
-async function loadPretext() {
-  if (!pretextModule) {
-    pretextModule = await import('@chenglou/pretext');
+let richInlineModule: PretextRichInline | null = null;
+
+async function loadRichInline(): Promise<PretextRichInline> {
+  if (!richInlineModule) {
+    richInlineModule = await import('@chenglou/pretext/rich-inline');
   }
 
-  return pretextModule;
+  return richInlineModule;
 }
 
-function getElementFont(el: HTMLElement): string {
-  return getComputedStyle(el).font;
+/**
+ * Canvas font shorthand matching an element's computed style.
+ * `weight` overrides font-weight — verses render bold, so they must be
+ * measured bold or every line carrying one comes out too narrow.
+ */
+function fontString(style: CSSStyleDeclaration, weight?: string): string {
+  return `${style.fontStyle} ${weight ?? style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
 }
 
-function getElementLineHeight(el: HTMLElement): number {
-  const style = getComputedStyle(el);
+function getElementLineHeight(style: CSSStyleDeclaration): number {
   const lh = Number.parseFloat(style.lineHeight);
 
   if (!Number.isNaN(lh)) {
@@ -58,93 +67,113 @@ function getElementLineHeight(el: HTMLElement): number {
   return Number.parseFloat(style.fontSize) * 1.8;
 }
 
-/** Gap before verse: small — bar ends close to the verse start */
-const CUTOUT_GAP_LEFT = 2;
-/** Gap after verse: larger — compensates for bold rendering being wider than measured */
-const CUTOUT_GAP_RIGHT = 40;
-
 /**
- * Measures the pixel width of a text string using pretext (single-line).
+ * Splits a paragraph into alternating non-verse / verse runs.
+ * Overlapping or touching verse matches are merged so runs strictly alternate.
  */
-function measureTextWidth(
-  pretext: typeof import('@chenglou/pretext'),
-  text: string,
-  font: string,
-  lineHeight: number,
-): number {
-  if (!text) {
-    return 0;
-  }
-  const prepared = pretext.prepareWithSegments(text, font);
-  const result = pretext.layoutWithLines(prepared, Infinity, lineHeight);
-
-  return result.lines[0]?.width ?? 0;
-}
-
-/**
- * Compute verse cutouts for all lines at once using joined text.
- * Handles verses that span across line boundaries.
- */
-function computeAllCutouts(
-  pretext: typeof import('@chenglou/pretext'),
-  lines: Array<{ text: string }>,
+export function splitIntoRuns(
+  paragraph: string,
   verses: string[],
-  font: string,
-  lineHeight: number,
-): VerseCutout[][] {
-  const lineOffsets: number[] = [];
-  const lineLengths: number[] = [];
-  let joined = '';
-
-  for (const line of lines) {
-    const trimmed = line.text.trimEnd();
-    lineOffsets.push(joined.length);
-    lineLengths.push(trimmed.length);
-    joined += trimmed + ' ';
-  }
-
-  const verseRanges: Array<{ start: number; end: number }> = [];
+): LineSegment[] {
+  const ranges: Array<{ start: number; end: number }> = [];
 
   for (const verse of verses) {
-    if (!verse || !verse.trim()) {continue;}
-    const idx = joined.indexOf(verse.trim());
+    const needle = verse?.trim();
+
+    if (!needle) {
+      continue;
+    }
+    const idx = paragraph.indexOf(needle);
 
     if (idx !== -1) {
-      verseRanges.push({ start: idx, end: idx + verse.trim().length });
+      ranges.push({ start: idx, end: idx + needle.length });
     }
   }
 
-  return lines.map((line, li) => {
-    const lineCharStart = lineOffsets[li];
-    const lineCharEnd = lineCharStart + lineLengths[li];
-    const cutouts: VerseCutout[] = [];
+  if (!ranges.length) {
+    return [{ text: paragraph, isVerse: false }];
+  }
 
-    for (const vr of verseRanges) {
-      if (vr.start >= lineCharEnd || vr.end <= lineCharStart) {continue;}
+  ranges.sort((a, b) => a.start - b.start);
 
-      const localCharStart = Math.max(0, vr.start - lineCharStart);
-      const localCharEnd = Math.min(line.text.length, vr.end - lineCharStart);
+  const merged: Array<{ start: number; end: number }> = [ranges[0]];
 
-      const beforeText = line.text.slice(0, localCharStart);
-      const verseText = line.text.slice(localCharStart, localCharEnd);
-      const startX = measureTextWidth(pretext, beforeText, font, lineHeight);
-      const verseWidth = measureTextWidth(pretext, verseText, font, lineHeight);
+  for (const range of ranges.slice(1)) {
+    const last = merged.at(-1)!;
 
-      cutouts.push({
-        startX: Math.max(0, startX - CUTOUT_GAP_LEFT),
-        endX: startX + verseWidth + CUTOUT_GAP_RIGHT,
-      });
+    if (range.start <= last.end) {
+      last.end = Math.max(last.end, range.end);
+
+      continue;
     }
+    merged.push(range);
+  }
 
-    return cutouts;
-  });
+  const runs: LineSegment[] = [];
+  let cursor = 0;
+
+  for (const range of merged) {
+    if (range.start > cursor) {
+      runs.push({ text: paragraph.slice(cursor, range.start), isVerse: false });
+    }
+    runs.push({ text: paragraph.slice(range.start, range.end), isVerse: true });
+    cursor = range.end;
+  }
+
+  if (cursor < paragraph.length) {
+    runs.push({ text: paragraph.slice(cursor), isVerse: false });
+  }
+
+  return runs;
 }
 
 /**
- * Measures text layout using pretext.
- * Splits text by paragraph breaks, computes per-line data with accurate
- * Y positioning using lineHeight arithmetic (guaranteed to match CSS).
- * Computes verse cutout positions for split marker bars.
+ * Folds one laid-out rich-inline line back into verse / non-verse runs.
+ * Collapsed inter-run whitespace is pushed outside the verse so the <mark>
+ * box hugs the verse text exactly — the marker cutouts are measured from it.
+ */
+function foldFragments(
+  fragments: Array<{ itemIndex: number; text: string; gapBefore: number }>,
+  runs: LineSegment[],
+): LineSegment[] {
+  const segments: LineSegment[] = [];
+
+  const push = (text: string, isVerse: boolean) => {
+    const last = segments.at(-1);
+
+    if (last && last.isVerse === isVerse) {
+      last.text += text;
+
+      return;
+    }
+    segments.push({ text, isVerse });
+  };
+
+  fragments.forEach((fragment, index) => {
+    const isVerse = runs[fragment.itemIndex]?.isVerse ?? false;
+    const previous = segments.at(-1);
+    const hasGap =
+      fragment.gapBefore > 0 && index > 0 && previous !== undefined;
+
+    // Keep the collapsed gap outside the <mark> so its box hugs the verse
+    if (hasGap && !previous.isVerse) {
+      previous.text += ' ';
+    }
+    push(
+      hasGap && previous?.isVerse && !isVerse
+        ? ' ' + fragment.text
+        : fragment.text,
+      isVerse,
+    );
+  });
+
+  return segments.filter((segment) => segment.text.length > 0);
+}
+
+/**
+ * Measures chapter text with pretext's rich-inline flow, so line breaking
+ * accounts for the bold verse runs instead of assuming a single font.
+ * Y positions come from lineHeight arithmetic, guaranteed to match CSS.
  */
 export function useMarkerLayout(
   elementRef: Ref<HTMLElement | null>,
@@ -169,62 +198,55 @@ export function useMarkerLayout(
       return;
     }
 
-    const pretext = await loadPretext();
-    const font = getElementFont(el);
-    const lineHeight = getElementLineHeight(el);
+    const rich = await loadRichInline();
+    const style = getComputedStyle(el);
+    const font = fontString(style);
+    const verseFont = fontString(style, 'bold');
+    const lineHeight = getElementLineHeight(style);
     const containerWidth = el.clientWidth;
 
-    if (!containerWidth || !font) {
+    if (!containerWidth) {
       return;
     }
 
     const paragraphs = textContent.value.split('\n\n').filter((p) => p.trim());
+    const activeVerses = verses?.value ?? [];
     const allLines: MarkerLine[] = [];
     let currentY = 0;
     let globalIndex = 0;
 
     for (let pi = 0; pi < paragraphs.length; pi++) {
-      // Paragraph gap: one blank line height (matches <br/><br/> in DOM)
+      // Paragraph gap: one blank line height (matches the rendered spacing)
       if (pi > 0) {
         currentY += lineHeight;
       }
 
-      const para = paragraphs[pi].trim();
-      const prepared = pretext.prepareWithSegments(para, font);
-      const result = pretext.layoutWithLines(
-        prepared,
-        containerWidth,
-        lineHeight,
+      const runs = splitIntoRuns(paragraphs[pi].trim(), activeVerses);
+      const prepared = rich.prepareRichInline(
+        runs.map((run) => ({
+          text: run.text,
+          font: run.isVerse ? verseFont : font,
+        })),
       );
 
-      for (let li = 0; li < result.lines.length; li++) {
-        const line = result.lines[li];
+      const paragraphStart = allLines.length;
+
+      rich.walkRichInlineLineRanges(prepared, containerWidth, (range) => {
+        const line = rich.materializeRichInlineLineRange(prepared, range);
+
         allLines.push({
-          text: line.text,
-          x: 0,
           y: currentY,
           width: line.width,
           lineHeight,
           index: globalIndex++,
-          isLastLine: li === result.lines.length - 1,
-          cutouts: [],
+          isLastLine: false,
+          segments: foldFragments(line.fragments, runs),
         });
         currentY += lineHeight;
-      }
-    }
+      });
 
-    // Compute cutouts across all lines (handles spanning verses)
-    if (verses?.value?.length) {
-      const allCutouts = computeAllCutouts(
-        pretext,
-        allLines,
-        verses.value,
-        font,
-        lineHeight,
-      );
-
-      for (let i = 0; i < allLines.length; i++) {
-        allLines[i].cutouts = allCutouts[i];
+      if (allLines.length > paragraphStart) {
+        allLines.at(-1)!.isLastLine = true;
       }
     }
 
@@ -238,7 +260,7 @@ export function useMarkerLayout(
 
   const debouncedCompute = useDebounceFn(computeLayout, 50);
 
-  watch(textContent, () => debouncedCompute());
+  watch([textContent, () => verses?.value], () => debouncedCompute());
 
   onMounted(async () => {
     if (import.meta.env.SSR) {

--- a/packages/front/src/features/haiku/composables/marker-svg.ts
+++ b/packages/front/src/features/haiku/composables/marker-svg.ts
@@ -3,17 +3,22 @@
  * black marker (stabilo) effect. Each line gets a unique randomized path
  * with organic wavy edges and micro-variations.
  *
- * Bars extend to near-full container width (like a real marker stroke
- * across the page), not matched to per-line text width.
+ * Bars span the line's own extent — the full container for justified lines,
+ * the measured text width for the last line of a paragraph — and are split
+ * around the verse cutouts measured from the rendered <mark> boxes.
  */
 
 export interface MarkerStrokeParams {
-  /** Container width — bar extends to (near) this width (px) */
-  containerWidth: number;
+  /** Extent the bar has to cover (px) */
+  extent: number;
   /** Line height (px) */
   lineHeight: number;
   /** Unique seed for deterministic randomness per line */
   seed: number;
+  /** Overshoot past the start — off when the bar butts against a verse */
+  bleedStart?: boolean;
+  /** Overshoot past the end — off when the bar butts against a verse */
+  bleedEnd?: boolean;
 }
 
 export interface MarkerStroke {
@@ -35,6 +40,17 @@ export interface MarkerStroke {
   noiseSeed: number;
 }
 
+export interface VerseCutout {
+  startX: number;
+  endX: number;
+}
+
+/**
+ * Bars narrower than this read as ink blobs rather than strokes. Gaps this
+ * small between two cutouts are swallowed instead, so no text leaks through.
+ */
+const MIN_SEGMENT_WIDTH = 14;
+
 // Seeded PRNG (mulberry32) for deterministic per-line randomness
 function createRng(seed: number): () => number {
   let t = seed | 0;
@@ -53,57 +69,79 @@ function lerp(a: number, b: number, t: number): number {
 }
 
 /**
- * Generates a single marker stroke for one text line.
- * The stroke spans near-full container width with organic edges.
+ * Traces one edge of the bar as a slightly uneven polyline, the way a marker
+ * tip wanders as it is dragged. Deviations stay sub-pixel-ish so the bar still
+ * reads as a straight stroke.
+ */
+function traceEdge(
+  from: number,
+  to: number,
+  y: number,
+  wobble: number,
+  steps: number,
+  rng: () => number,
+): string[] {
+  const points: string[] = [];
+
+  for (let i = 1; i <= steps; i++) {
+    const x = lerp(from, to, i / steps);
+    const dy = i === steps ? 0 : lerp(-wobble, wobble, rng());
+    points.push(`L${x.toFixed(1)},${(y + dy).toFixed(1)}`);
+  }
+
+  return points;
+}
+
+/**
+ * Generates a single marker stroke covering `extent` pixels of one text line.
  */
 export function generateMarkerStroke(params: MarkerStrokeParams): MarkerStroke {
-  const { containerWidth, lineHeight, seed } = params;
+  const {
+    extent,
+    lineHeight,
+    seed,
+    bleedStart = true,
+    bleedEnd = true,
+  } = params;
   const rng = createRng(seed);
 
-  // Bar dimensions — thick bars that nearly touch adjacent lines
-  const barHeightRatio = lerp(0.75, 0.82, rng());
-  const barHeight = lineHeight * barHeightRatio;
-  const yOffset = (lineHeight - barHeight) / 2 + lerp(-0.3, 0.3, rng());
+  // Bar height: comfortably clears ascenders and descenders while leaving
+  // a strip of paper between consecutive lines, like real redaction passes
+  const barHeight = lineHeight * lerp(0.68, 0.76, rng());
+  const yOffset = (lineHeight - barHeight) / 2 + lerp(-0.4, 0.4, rng());
 
-  // Width: generous overshoot on both sides to fully cover text
-  const leftOvershoot = lerp(
-    containerWidth * 0.005,
-    containerWidth * 0.012,
-    rng(),
-  );
-  const rightOvershoot = lerp(
-    containerWidth * 0.01,
-    containerWidth * 0.025,
-    rng(),
-  );
-  const totalWidth = containerWidth + leftOvershoot + rightOvershoot;
+  // Width: small overshoot so no glyph edge pokes out at the line ends.
+  // Suppressed where the bar stops at a verse, or it would creep over it.
+  const leftOvershoot = bleedStart ? lerp(1.5, 4.5, rng()) : 0;
+  const rightOvershoot = bleedEnd ? lerp(2.5, 7, rng()) : 0;
+  const totalWidth = extent + leftOvershoot + rightOvershoot;
   const xOffset = -leftOvershoot;
 
-  // Visual micro-randomizations
-  const rotation = lerp(-0.25, 0.25, rng());
-  const opacity = lerp(0.88, 0.96, rng());
+  // Visual micro-randomizations. Near-opaque: a redacted word must not be
+  // legible through the ink, only sensed as a shape.
+  const rotation = lerp(-0.22, 0.22, rng());
+  const opacity = lerp(0.99, 1, rng());
   const noiseSeed = Math.floor(rng() * 10000);
 
-  // Straight edges, randomized caps only
   const topY = 0;
   const bottomY = barHeight;
+  const steps = Math.max(2, Math.min(10, Math.round(totalWidth / 55)));
+  const wobble = lerp(0.35, 0.75, rng());
 
   // Right cap — varied shape
-  const rightCapBulge = lerp(1, 6, rng());
-  const rightCapYBias = lerp(0.25, 0.75, rng());
-  const rightCapCpY = topY + (bottomY - topY) * rightCapYBias;
+  const rightCapBulge = lerp(1, 5, rng());
+  const rightCapCpY = lerp(topY, bottomY, lerp(0.25, 0.75, rng()));
 
   // Left cap — varied shape with asymmetric control point
-  const leftCapBulge = lerp(-8, -1, rng());
-  const leftCapYBias = lerp(0.15, 0.85, rng());
-  const leftCapCpY = topY + (bottomY - topY) * leftCapYBias;
+  const leftCapBulge = lerp(-6, -1, rng());
+  const leftCapCpY = lerp(topY, bottomY, lerp(0.15, 0.85, rng()));
 
-  // Path: straight top → right cap → straight bottom → left cap
+  // Path: wandering top edge → right cap → wandering bottom edge → left cap
   const d = [
     `M0,${topY.toFixed(1)}`,
-    `L${totalWidth.toFixed(1)},${topY.toFixed(1)}`,
+    ...traceEdge(0, totalWidth, topY, wobble, steps, rng),
     `Q${(totalWidth + rightCapBulge).toFixed(1)},${rightCapCpY.toFixed(1)} ${totalWidth.toFixed(1)},${bottomY.toFixed(1)}`,
-    `L0,${bottomY.toFixed(1)}`,
+    ...traceEdge(totalWidth, 0, bottomY, wobble, steps, rng),
     `Q${leftCapBulge.toFixed(1)},${leftCapCpY.toFixed(1)} 0,${topY.toFixed(1)}`,
     'Z',
   ].join(' ');
@@ -128,85 +166,124 @@ export interface BarSegment {
 }
 
 /**
+ * Clamps cutouts to the line, drops empty ones and merges neighbours whose
+ * gap is too narrow to hold a readable bar.
+ */
+function normalizeCutouts(
+  cutouts: VerseCutout[],
+  extent: number,
+): VerseCutout[] {
+  const clamped = cutouts
+    .map((cutout) => ({
+      startX: Math.max(0, Math.min(cutout.startX, extent)),
+      endX: Math.max(0, Math.min(cutout.endX, extent)),
+    }))
+    .filter((cutout) => cutout.endX > cutout.startX)
+    .sort((a, b) => a.startX - b.startX);
+
+  if (!clamped.length) {
+    return [];
+  }
+
+  const merged: VerseCutout[] = [clamped[0]];
+
+  for (const cutout of clamped.slice(1)) {
+    const last = merged.at(-1)!;
+
+    if (cutout.startX - last.endX < MIN_SEGMENT_WIDTH) {
+      last.endX = Math.max(last.endX, cutout.endX);
+
+      continue;
+    }
+    merged.push(cutout);
+  }
+
+  return merged;
+}
+
+/**
  * Generates bar segments for a single line, splitting around verse cutouts.
- * Lines without cutouts produce one full-width segment.
- * Lines with cutouts produce multiple segments (bar-gap-bar pattern).
+ * Lines without cutouts produce one full-extent segment.
  */
 export function generateLineSegments(
-  containerWidth: number,
+  extent: number,
   lineHeight: number,
-  cutouts: Array<{ startX: number; endX: number }>,
+  cutouts: VerseCutout[],
   seed: number,
 ): BarSegment[] {
-  if (!cutouts.length) {
+  const windows = normalizeCutouts(cutouts, extent);
+
+  if (!windows.length) {
     return [
       {
         x: 0,
-        stroke: generateMarkerStroke({ containerWidth, lineHeight, seed }),
+        stroke: generateMarkerStroke({ extent, lineHeight, seed }),
       },
     ];
   }
 
-  // Sort cutouts by startX
-  const sorted = [...cutouts].sort((a, b) => a.startX - b.startX);
   const segments: BarSegment[] = [];
   let currentX = 0;
   let segSeed = seed;
 
-  for (const cutout of sorted) {
-    const segWidth = cutout.startX - currentX;
-
-    if (segWidth > 20) {
-      segments.push({
-        x: currentX,
-        stroke: generateMarkerStroke({
-          containerWidth: segWidth,
-          lineHeight,
-          seed: segSeed,
-        }),
-      });
+  const addSegment = (from: number, to: number) => {
+    if (to - from < MIN_SEGMENT_WIDTH) {
+      return;
     }
-    currentX = cutout.endX;
+    segments.push({
+      x: from,
+      stroke: generateMarkerStroke({
+        extent: to - from,
+        lineHeight,
+        seed: segSeed,
+        bleedStart: from === 0,
+        bleedEnd: to === extent,
+      }),
+    });
+  };
+
+  for (const window of windows) {
+    addSegment(currentX, window.startX);
+    currentX = window.endX;
     segSeed += 3571; // Different seed per segment
   }
 
-  // Final segment after last cutout
-  const finalWidth = containerWidth - currentX;
-
-  if (finalWidth > 20) {
-    segments.push({
-      x: currentX,
-      stroke: generateMarkerStroke({
-        containerWidth: finalWidth,
-        lineHeight,
-        seed: segSeed,
-      }),
-    });
-  }
+  addSegment(currentX, extent);
 
   return segments;
 }
 
+export interface MarkerLineExtent {
+  lineHeight: number;
+  index: number;
+  /** Natural text width (px) — used to shrinkwrap the last line of a paragraph */
+  width: number;
+  isLastLine: boolean;
+}
+
 /**
  * Generates bar segments for all lines, handling verse cutouts.
+ * Justified lines are covered edge to edge; the last line of a paragraph is
+ * left-aligned, so its bar stops just past the text instead of running on.
  */
 export function generateAllLineSegments(
-  lines: Array<{
-    lineHeight: number;
-    index: number;
-    cutouts: Array<{ startX: number; endX: number }>;
-  }>,
+  lines: MarkerLineExtent[],
   containerWidth: number,
+  cutouts: VerseCutout[][] = [],
   baseSeed = 42,
 ): BarSegment[][] {
-  return lines.map((line) =>
-    generateLineSegments(
-      containerWidth,
+  return lines.map((line, index) => {
+    const extent = line.isLastLine
+      ? Math.min(containerWidth, line.width + line.lineHeight * 0.2)
+      : containerWidth;
+
+    return generateLineSegments(
+      extent,
       line.lineHeight,
-      line.cutouts,
+      cutouts[index] ?? [],
       baseSeed + line.index * 7919,
-    ),
-  );
+    );
+  });
 }
 
 /**
@@ -219,7 +296,7 @@ export function generateMarkerStrokes(
 ): MarkerStroke[] {
   return lines.map((line) =>
     generateMarkerStroke({
-      containerWidth,
+      extent: containerWidth,
       lineHeight: line.lineHeight,
       seed: baseSeed + line.index * 7919,
     }),

--- a/packages/front/tests/unit/features/haiku/composables/marker-layout.test.ts
+++ b/packages/front/tests/unit/features/haiku/composables/marker-layout.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { splitIntoRuns } from '@/features/haiku/composables/marker-layout';
+
+describe('splitIntoRuns', () => {
+  it('returns the whole paragraph as one non-verse run when nothing matches', () => {
+    const runs = splitIntoRuns('A quiet pond in spring.', ['no such verse']);
+
+    expect(runs).toEqual([{ text: 'A quiet pond in spring.', isVerse: false }]);
+  });
+
+  it('splits a paragraph around a verse', () => {
+    const runs = splitIntoRuns('Before the verse text after.', ['the verse']);
+
+    expect(runs).toEqual([
+      { text: 'Before ', isVerse: false },
+      { text: 'the verse', isVerse: true },
+      { text: ' text after.', isVerse: false },
+    ]);
+  });
+
+  it('keeps runs alternating for several verses', () => {
+    const runs = splitIntoRuns('one two three four five', ['two', 'four']);
+
+    expect(runs.map((r) => r.isVerse)).toEqual([
+      false,
+      true,
+      false,
+      true,
+      false,
+    ]);
+  });
+
+  it('orders runs by position, not by verse order', () => {
+    const runs = splitIntoRuns('one two three four five', ['four', 'two']);
+
+    expect(runs.map((r) => r.text)).toEqual([
+      'one ',
+      'two',
+      ' three ',
+      'four',
+      ' five',
+    ]);
+  });
+
+  it('merges overlapping verse matches into a single run', () => {
+    const runs = splitIntoRuns('the quiet pond', ['the quiet', 'quiet pond']);
+
+    expect(runs).toEqual([{ text: 'the quiet pond', isVerse: true }]);
+  });
+
+  it('ignores blank verses and trims the ones it matches', () => {
+    const runs = splitIntoRuns('a still pond', ['', '  ', ' still ']);
+
+    expect(runs).toEqual([
+      { text: 'a ', isVerse: false },
+      { text: 'still', isVerse: true },
+      { text: ' pond', isVerse: false },
+    ]);
+  });
+
+  it('handles a verse covering the whole paragraph', () => {
+    const runs = splitIntoRuns('a still pond', ['a still pond']);
+
+    expect(runs).toEqual([{ text: 'a still pond', isVerse: true }]);
+  });
+});

--- a/packages/front/tests/unit/features/haiku/composables/marker-svg.test.ts
+++ b/packages/front/tests/unit/features/haiku/composables/marker-svg.test.ts
@@ -8,59 +8,55 @@ import {
 
 describe('generateMarkerStroke', () => {
   it('produces a deterministic stroke for a given seed', () => {
-    const a = generateMarkerStroke({
-      containerWidth: 200,
-      lineHeight: 30,
-      seed: 42,
-    });
-    const b = generateMarkerStroke({
-      containerWidth: 200,
-      lineHeight: 30,
-      seed: 42,
-    });
+    const a = generateMarkerStroke({ extent: 200, lineHeight: 30, seed: 42 });
+    const b = generateMarkerStroke({ extent: 200, lineHeight: 30, seed: 42 });
 
     expect(a).toEqual(b);
   });
 
   it('produces different strokes for different seeds', () => {
-    const a = generateMarkerStroke({
-      containerWidth: 200,
-      lineHeight: 30,
-      seed: 1,
-    });
-    const b = generateMarkerStroke({
-      containerWidth: 200,
-      lineHeight: 30,
-      seed: 2,
-    });
+    const a = generateMarkerStroke({ extent: 200, lineHeight: 30, seed: 1 });
+    const b = generateMarkerStroke({ extent: 200, lineHeight: 30, seed: 2 });
 
     expect(a.path).not.toBe(b.path);
   });
 
   it('returns a well-formed stroke object with sane bounds', () => {
     const stroke = generateMarkerStroke({
-      containerWidth: 300,
+      extent: 300,
       lineHeight: 40,
       seed: 7,
     });
 
     expect(stroke.path.startsWith('M0,')).toBeTruthy();
     expect(stroke.path.endsWith('Z')).toBeTruthy();
-    // bar wider than container (overshoot on both sides)
+    // bar wider than the extent it covers (overshoot on both sides)
     expect(stroke.width).toBeGreaterThan(300);
-    // bar height is a ratio (~0.75-0.82) of line height
-    expect(stroke.height).toBeGreaterThan(40 * 0.7);
-    expect(stroke.height).toBeLessThan(40);
+    // bar height is a ratio (~0.68-0.76) of line height, leaving paper between lines
+    expect(stroke.height).toBeGreaterThan(40 * 0.67);
+    expect(stroke.height).toBeLessThan(40 * 0.77);
     // xOffset is the negative left overshoot
     expect(stroke.xOffset).toBeLessThanOrEqual(0);
-    expect(stroke.opacity).toBeGreaterThanOrEqual(0.88);
-    expect(stroke.opacity).toBeLessThanOrEqual(0.96);
+    // near-opaque: a redacted word must not be legible through the ink
+    expect(stroke.opacity).toBeGreaterThanOrEqual(0.96);
+    expect(stroke.opacity).toBeLessThanOrEqual(1);
     expect(Number.isInteger(stroke.noiseSeed)).toBeTruthy();
+  });
+
+  it('traces wandering edges rather than a plain rectangle', () => {
+    const stroke = generateMarkerStroke({
+      extent: 400,
+      lineHeight: 30,
+      seed: 3,
+    });
+
+    // several line-to commands per edge, not a single one
+    expect(stroke.path.match(/L/g)?.length).toBeGreaterThan(4);
   });
 });
 
 describe('generateLineSegments', () => {
-  it('returns a single full-width segment when there are no cutouts', () => {
+  it('returns a single full-extent segment when there are no cutouts', () => {
     const segments = generateLineSegments(400, 30, [], 10);
 
     expect(segments).toHaveLength(1);
@@ -82,16 +78,41 @@ describe('generateLineSegments', () => {
   });
 
   it('skips segments narrower than the minimum width', () => {
-    // cutout starts at 10 -> leading segment width 10 (<= 20) is skipped
+    // leading 0..10 and trailing 390..400 are both too narrow to draw
     const segments = generateLineSegments(
       400,
       30,
-      [{ startX: 10, endX: 380 }],
+      [{ startX: 10, endX: 390 }],
       10,
     );
 
-    // only the trailing segment 380..400 has width 20 which is not > 20, so skipped too
     expect(segments).toHaveLength(0);
+  });
+
+  it('merges cutouts too close together so no text leaks between them', () => {
+    const segments = generateLineSegments(
+      400,
+      30,
+      [
+        { startX: 100, endX: 150 },
+        { startX: 155, endX: 200 },
+      ],
+      10,
+    );
+
+    // the 5px gap is swallowed: one bar before, one after
+    expect(segments.map((s) => s.x)).toEqual([0, 200]);
+  });
+
+  it('clamps cutouts to the line extent', () => {
+    const segments = generateLineSegments(
+      400,
+      30,
+      [{ startX: -50, endX: 120 }],
+      10,
+    );
+
+    expect(segments.map((s) => s.x)).toEqual([120]);
   });
 
   it('sorts cutouts before processing', () => {
@@ -113,15 +134,39 @@ describe('generateLineSegments', () => {
 describe('generateAllLineSegments', () => {
   it('generates segments for each line based on its index and cutouts', () => {
     const lines = [
-      { lineHeight: 30, index: 0, cutouts: [] },
-      { lineHeight: 30, index: 1, cutouts: [{ startX: 100, endX: 200 }] },
+      { lineHeight: 30, index: 0, width: 400, isLastLine: false },
+      { lineHeight: 30, index: 1, width: 400, isLastLine: false },
     ];
 
-    const result = generateAllLineSegments(lines, 400, 42);
+    const result = generateAllLineSegments(lines, 400, [
+      [],
+      [{ startX: 100, endX: 200 }],
+    ]);
 
     expect(result).toHaveLength(2);
     expect(result[0]).toHaveLength(1);
     expect(result[1]).toHaveLength(2);
+  });
+
+  it('covers justified lines edge to edge', () => {
+    const [segments] = generateAllLineSegments(
+      [{ lineHeight: 30, index: 0, width: 180, isLastLine: false }],
+      400,
+    );
+
+    // the line is justified to the container, so the bar spans it whole
+    expect(segments[0].stroke.width).toBeGreaterThan(400);
+  });
+
+  it('shrinkwraps the last line of a paragraph to its measured text', () => {
+    const [segments] = generateAllLineSegments(
+      [{ lineHeight: 30, index: 0, width: 180, isLastLine: true }],
+      400,
+    );
+
+    // left-aligned last line: the bar stops just past the text
+    expect(segments[0].stroke.width).toBeLessThan(220);
+    expect(segments[0].stroke.width).toBeGreaterThan(180);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^8.0.2
         version: 8.0.2(@capacitor/core@8.3.4)
       '@chenglou/pretext':
-        specifier: ^0.0.7
-        version: 0.0.7
+        specifier: ^0.0.8
+        version: 0.0.8
       '@fingerprintjs/botd':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1301,8 +1301,8 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
-  '@chenglou/pretext@0.0.7':
-    resolution: {integrity: sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==}
+  '@chenglou/pretext@0.0.8':
+    resolution: {integrity: sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==}
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -3470,6 +3470,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -4263,10 +4264,12 @@ packages:
   conventional-changelog-atom@2.0.8:
     resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@2.0.8:
     resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-conventionalcommits@4.6.3:
     resolution: {integrity: sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==}
@@ -4279,26 +4282,32 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@3.0.9:
     resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@2.0.6:
     resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@3.0.11:
     resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@2.0.9:
     resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -5649,7 +5658,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -5659,7 +5668,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -10987,7 +10996,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.3.4
 
-  '@chenglou/pretext@0.0.7': {}
+  '@chenglou/pretext@0.0.8': {}
 
   '@chevrotain/types@11.1.2': {}
 


### PR DESCRIPTION
## Regression: black marker disappears after crafting a new haiku

`blackMarker` is local `HaikuChapter` state that nothing ever reset, and the component is never unmounted between haikus (`haiku` is replaced in place, never nulled). So once you clicked the text to read a chapter, **every** haiku crafted afterwards rendered unredacted.

Reproduced in the browser: crafting 3× without revealing kept the marker every time; revealing once and then crafting lost it, and it never came back.

Fixed by re-arming the redaction when a new haiku arrives (bots still get readable text), and clearing the stale spotlight with it.

## Sharper marker render

The underlying defect: pretext measured the whole chapter in the **regular** font while verses render **bold**. Lines carrying a verse therefore came out too narrow, overflowed and wrapped on top of the next absolutely-positioned line — the smeared, struck-through look — and the verse cutouts drifted by 10–20px depending on where the verse sat, papered over by a `CUTOUT_GAP_RIGHT = 40` fudge.

- `marker-layout.ts` now lays out through `@chenglou/pretext/rich-inline`: each paragraph is split into regular / bold runs, so line breaking accounts for the bold verses and lines no longer overflow. It also emits the per-line runs, so `PretextChapter` stops re-deriving verse segmentation by string-joining line texts. It now watches `verses`, which it previously did not.
- Cutouts are measured from the rendered `<mark>` boxes with their padding discounted, so bar edges land on the verse exactly whatever justification did to the line. Both fudge constants are gone.
- `marker-svg.ts`: bars no longer overshoot into a verse window; near-opaque, so redacted text is not legible through the ink; hand-traced wandering edges; shorter bars leave paper between lines; the last line of a paragraph shrinkwraps to its text instead of running to the page edge; cutouts closer than 14px merge so no sliver of text leaks between them.
- `MarkerOverlay` (title / author) measures real line boxes with a `TreeWalker` + `Range` instead of `scrollHeight / lineHeight`, so bars hug the centred title and the author's `by` prefix is covered too.
- `HaikuChapter`: the revealed highlight's padding is cancelled by a matching negative margin, so revealing a verse never re-flows the pretext-measured line.

Bumps `@chenglou/pretext` 0.0.7 → 0.0.8 — `^0.0.7` cannot reach it on its own, and both releases carry rich-inline and line-breaking fixes that this path depends on.

## Verification

- `vue-tsc`, oxlint, stylelint, oxfmt clean
- 378 unit tests pass — `marker-svg.test.ts` rewritten for the new API, `marker-layout.test.ts` added for run splitting
- production `vite-ssg` build succeeds
- manually checked against a local backend: redacted, revealed, and reveal → craft → redacted again

## Notes

- The reset also fires on history back / forward, on the reasoning that each chapter is its own puzzle. Easy to scope to fresh haikus only if that is not wanted.
- `depcruise` reports 204 pre-existing violations (unresolved `@/` aliases across the front package). None are in these files and none are touched here.
